### PR TITLE
feat: implementa Edição SOAP e Agenda em Calendário — Phase 10

### DIFF
--- a/.docs/CHANGELOG.md
+++ b/.docs/CHANGELOG.md
@@ -9,6 +9,23 @@ e o projeto segue [Conventional Commits](https://www.conventionalcommits.org/) e
 
 ### Added
 
+- **Phase 10 — Edição SOAP e Agenda em Calendário**
+  - `SessionForm` refatorado para suportar `mode="create" | "edit"` com `initialValues`,
+    incluindo opção de status `CANCELADO` em edição
+  - Nova rota `/atendimentos/[id]/editar` carrega a sessão via `getSessionUseCase` e
+    persiste alterações com `PUT /api/sessions/:id` (mantém validação de data passada
+    para `AGENDADO`)
+  - Botão "Editar SOAP" no `SessionCard` apontando para a nova rota de edição
+  - Componente `AgendaViewToggle` com tabs "Lista" e "Calendário" preservando filtro
+    domiciliar e mês corrente
+  - Componente `MonthCalendar` (client) com grid 6×7, navegação de mês via Link, destaque
+    do dia atual, contagem por dia, indicadores de status e ícone de domiciliar; clique
+    em um dia exibe as sessões do dia em painel lateral
+  - `/agenda?view=calendar` busca sessões do mês via `listSessionsUseCase`
+    (`from`/`to` calculados a partir do parâmetro `month=YYYY-MM`)
+  - `DomiciliarToggle` agora preserva os demais query params ao alternar visão
+  - Limite máximo de `listSessionsDTO` aumentado de 100 para 500 para suportar a visão mensal
+
 - **Phase 9 — Polimento UX e Documentos v1.1**
   - Componente `DocumentTypeCards` com faixa de cards contextuais no topo de `/documentos`
     (Relatório de evolução, Laudo fisioterapêutico, Encaminhamento "em breve" e Declaração de horas)

--- a/.docs/CONTEXT.md
+++ b/.docs/CONTEXT.md
@@ -4,6 +4,13 @@
 
 ## Fase Atual
 
+**Phase 10 — Edição SOAP e Agenda em Calendário concluída**
+`SessionForm` em modo create/edit, rota `/atendimentos/[id]/editar` para revisar/atualizar
+campos SOAP e dados do atendimento, e nova visão `/agenda?view=calendar&month=YYYY-MM` com
+calendário mensal, contagem por dia, indicadores de status e painel lateral de sessões do
+dia selecionado. `DomiciliarToggle` agora preserva os demais params; limite do
+`listSessionsDTO` elevado para 500.
+
 **Phase 9 — Polimento UX e Documentos v1.1 concluída**
 Cards contextuais no topo de `/documentos`, tooltip de período no modal de geração,
 QuickActions com botões mais visíveis, `DomiciliarToggle` com loading, botão "Cancelar"
@@ -20,7 +27,6 @@ Campos de endereço e prioridade no modelo `Patient`, seção de logística na f
 
 Seguir a ordem arquitetada:
 
-- **Phase 10** — Edição SOAP e Agenda em Calendário
 - **Phase 11** — E-mails com Gmail App Password
 - **Phase 12** — Integração com Google Calendar
 

--- a/.docs/tasks/phase-10-clinical-agenda-flow.md
+++ b/.docs/tasks/phase-10-clinical-agenda-flow.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-- [x] Todo
+- [ ] Todo
 - [ ] In Progress
-- [ ] Done
+- [x] Done
 
 ## Contexto
 

--- a/README.md
+++ b/README.md
@@ -160,17 +160,18 @@ Após o seed:
 - Phase 9 — Polimento UX e Documentos v1.1 (cards contextuais, tooltip de período,
   QuickActions revisado, loading no filtro domiciliar, botão Cancelar terracota,
   rebrand "Experiência Clínica Fluida")
+- Phase 10 — Edição SOAP e Agenda em Calendário (rota `/atendimentos/[id]/editar`,
+  `SessionForm` em modo create/edit, visão `/agenda?view=calendar` com calendário mensal
+  e painel de sessões do dia)
 
 ### 🗺️ Planejado
 
-- Phase 10 — Edição SOAP e Agenda em Calendário
 - Phase 11 — E-mails com Gmail App Password
 - Phase 12 — Integração com Google Calendar
 
 ### ➡️ Próximo Passo
 
-Executar **Phase 10 — Edição SOAP e Agenda em Calendário**.
+Executar **Phase 11 — E-mails com Gmail App Password**.
 
-Tasks restantes em `.docs/tasks/phase-10-clinical-agenda-flow.md`,
-`.docs/tasks/phase-11-email-notifications.md` e
+Tasks restantes em `.docs/tasks/phase-11-email-notifications.md` e
 `.docs/tasks/phase-12-google-calendar.md`.

--- a/src/app/(app)/agenda/page.tsx
+++ b/src/app/(app)/agenda/page.tsx
@@ -1,9 +1,14 @@
 import Link from 'next/link'
 import { CalendarCheck2, CalendarDays, Home } from 'lucide-react'
 import { getSession } from '@/lib/session'
-import { formatAgendaDayLabel, formatCalendarDateKey } from '@/lib/date'
+import {
+  formatAgendaDayLabel,
+  formatCalendarDateKey,
+} from '@/lib/date'
 import { SessionCard } from '@/components/sessions/SessionCard'
 import { DomiciliarToggle } from '@/components/agenda/DomiciliarToggle'
+import { AgendaViewToggle } from '@/components/agenda/AgendaViewToggle'
+import { MonthCalendar } from '@/components/agenda/MonthCalendar'
 import { listSessionsUseCase } from '@/server/modules/sessions/application/list-sessions'
 
 const PRIORITY_ORDER: Record<string, number> = { URGENT: 0, HIGH: 1, NORMAL: 2 }
@@ -19,15 +24,85 @@ function sortByPriority<
   })
 }
 
+function pad(value: number) {
+  return String(value).padStart(2, '0')
+}
+
+function currentMonthKey(now: Date = new Date()) {
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}`
+}
+
+function parseMonthKey(value?: string) {
+  if (!value || !/^\d{4}-\d{2}$/.test(value)) return currentMonthKey()
+  return value
+}
+
+function getMonthRange(monthKey: string) {
+  const [yearStr, monthStr] = monthKey.split('-')
+  const year = Number(yearStr)
+  const monthIndex = Number(monthStr) - 1
+  const from = new Date(Date.UTC(year, monthIndex, 1, 0, 0, 0, 0))
+  const to = new Date(Date.UTC(year, monthIndex + 1, 0, 23, 59, 59, 999))
+  return { from, to }
+}
+
 export default async function AgendaPage({
   searchParams,
 }: {
-  searchParams: Promise<{ domiciliar?: string }>
+  searchParams: Promise<{ domiciliar?: string; view?: string; month?: string }>
 }) {
-  const { domiciliar } = await searchParams
-  const isHomeCareMode = domiciliar === '1'
+  const params = await searchParams
+  const isHomeCareMode = params.domiciliar === '1'
+  const view: 'list' | 'calendar' = params.view === 'calendar' ? 'calendar' : 'list'
+  const monthKey = parseMonthKey(params.month)
 
   const session = await getSession()
+
+  if (view === 'calendar') {
+    const { from, to } = getMonthRange(monthKey)
+    const { sessions } = await listSessionsUseCase(session.userId!, {
+      from: from.toISOString(),
+      to: to.toISOString(),
+      limit: 500,
+      order: 'asc',
+      ...(isHomeCareMode ? { type: 'HOME_CARE' } : {}),
+    })
+
+    const sessionsByDay = sessions.reduce<Record<string, typeof sessions>>((acc, item) => {
+      const key = formatCalendarDateKey(item.date)
+      ;(acc[key] ??= []).push(item)
+      return acc
+    }, {})
+
+    if (isHomeCareMode) {
+      for (const key of Object.keys(sessionsByDay)) {
+        sessionsByDay[key] = sortByPriority(sessionsByDay[key])
+      }
+    }
+
+    const todayKey = formatCalendarDateKey(new Date())
+    const homeCareCount = sessions.filter((item) => item.type === 'HOME_CARE').length
+
+    return (
+      <div className="space-y-6 sm:space-y-8">
+        <AgendaHeader
+          isHomeCareMode={isHomeCareMode}
+          view={view}
+          monthKey={monthKey}
+          totalLabel={`${sessions.length} no mês`}
+          homeCareCount={homeCareCount}
+        />
+
+        <MonthCalendar
+          monthKey={monthKey}
+          todayKey={todayKey}
+          domiciliar={isHomeCareMode}
+          sessionsByDay={sessionsByDay}
+        />
+      </div>
+    )
+  }
+
   const { sessions } = await listSessionsUseCase(session.userId!, {
     status: 'AGENDADO',
     from: new Date().toISOString(),
@@ -66,49 +141,13 @@ export default async function AgendaPage({
 
   return (
     <div className="space-y-6 sm:space-y-8">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-        <div>
-          <p className="font-body text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-            {isHomeCareMode ? 'Atendimentos Domiciliares' : 'Próximos'}
-          </p>
-          <h1 className="font-display text-[30px] font-bold leading-tight text-foreground sm:text-[36px]">
-            Agenda
-          </h1>
-          <p className="mt-1 font-body text-[14px] text-muted-foreground">
-            {isHomeCareMode
-              ? 'Visitas domiciliares ordenadas por prioridade.'
-              : 'Agendamentos e atendimentos domiciliares.'}
-          </p>
-        </div>
-
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-          <DomiciliarToggle active={isHomeCareMode} />
-          <Link
-            href="/pacientes"
-            className="flex items-center justify-center gap-2 rounded-xl bg-primary px-4 py-2.5 font-body text-[13px] font-semibold text-primary-foreground shadow-glow transition-colors hover:bg-primary-hover"
-          >
-            <CalendarDays className="h-4 w-4" />
-            Novo agendamento
-          </Link>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <div className="rounded-[18px] border border-border bg-card p-4 shadow-sm">
-          <p className="font-body text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-            Próximas sessões
-          </p>
-          <p className="mt-3 font-display text-[32px] font-bold text-foreground">
-            {sessions.length}
-          </p>
-        </div>
-        <div className="rounded-[18px] border border-border bg-card p-4 shadow-sm">
-          <p className="font-body text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-            Domiciliares
-          </p>
-          <p className="mt-3 font-display text-[32px] font-bold text-foreground">{homeCareCount}</p>
-        </div>
-      </div>
+      <AgendaHeader
+        isHomeCareMode={isHomeCareMode}
+        view={view}
+        monthKey={monthKey}
+        totalLabel={`${sessions.length}`}
+        homeCareCount={homeCareCount}
+      />
 
       {groupedSessions.length === 0 ? (
         <div className="flex min-h-[320px] items-center justify-center rounded-[24px] border border-dashed border-border bg-card/75 px-6 py-12 sm:px-10">
@@ -167,5 +206,68 @@ export default async function AgendaPage({
         </div>
       )}
     </div>
+  )
+}
+
+function AgendaHeader({
+  isHomeCareMode,
+  view,
+  monthKey,
+  totalLabel,
+  homeCareCount,
+}: {
+  isHomeCareMode: boolean
+  view: 'list' | 'calendar'
+  monthKey: string
+  totalLabel: string
+  homeCareCount: number
+}) {
+  return (
+    <>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="font-body text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            {isHomeCareMode ? 'Atendimentos Domiciliares' : view === 'calendar' ? 'Visão mensal' : 'Próximos'}
+          </p>
+          <h1 className="font-display text-[30px] font-bold leading-tight text-foreground sm:text-[36px]">
+            Agenda
+          </h1>
+          <p className="mt-1 font-body text-[14px] text-muted-foreground">
+            {isHomeCareMode
+              ? 'Visitas domiciliares ordenadas por prioridade.'
+              : view === 'calendar'
+                ? 'Atendimentos do mês com filtro por dia.'
+                : 'Agendamentos e atendimentos domiciliares.'}
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:flex-wrap">
+          <AgendaViewToggle view={view} domiciliar={isHomeCareMode} month={monthKey} />
+          <DomiciliarToggle active={isHomeCareMode} />
+          <Link
+            href="/pacientes"
+            className="flex items-center justify-center gap-2 rounded-xl bg-primary px-4 py-2.5 font-body text-[13px] font-semibold text-primary-foreground shadow-glow transition-colors hover:bg-primary-hover"
+          >
+            <CalendarDays className="h-4 w-4" />
+            Novo agendamento
+          </Link>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div className="rounded-[18px] border border-border bg-card p-4 shadow-sm">
+          <p className="font-body text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            {view === 'calendar' ? 'Atendimentos no mês' : 'Próximas sessões'}
+          </p>
+          <p className="mt-3 font-display text-[32px] font-bold text-foreground">{totalLabel}</p>
+        </div>
+        <div className="rounded-[18px] border border-border bg-card p-4 shadow-sm">
+          <p className="font-body text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            Domiciliares
+          </p>
+          <p className="mt-3 font-display text-[32px] font-bold text-foreground">{homeCareCount}</p>
+        </div>
+      </div>
+    </>
   )
 }

--- a/src/app/(app)/atendimentos/[id]/editar/page.tsx
+++ b/src/app/(app)/atendimentos/[id]/editar/page.tsx
@@ -1,0 +1,97 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ChevronLeft, ClipboardEdit } from 'lucide-react'
+import { getSession } from '@/lib/session'
+import { SessionForm } from '@/components/sessions/SessionForm'
+import {
+  getSessionUseCase,
+  SessionNotFoundError,
+} from '@/server/modules/sessions/application/get-session'
+
+const AREA_LABELS: Record<string, string> = {
+  PILATES: 'Pilates',
+  MOTOR: 'Fisioterapia Motora',
+  AESTHETIC: 'Fisioterapia Estética',
+  HOME_CARE: 'Atendimento Domiciliar',
+}
+
+async function loadSession(id: string, userId: string) {
+  try {
+    return await getSessionUseCase(id, userId)
+  } catch (error) {
+    if (error instanceof SessionNotFoundError) {
+      return null
+    }
+    throw error
+  }
+}
+
+export default async function EditarAtendimentoPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const session = await getSession()
+  const clinicalSession = await loadSession(id, session.userId!)
+
+  if (!clinicalSession) {
+    notFound()
+  }
+
+  return (
+    <div className="max-w-[1120px] space-y-6 sm:space-y-8">
+      <div>
+        <Link
+          href="/atendimentos"
+          className="mb-4 flex items-center gap-1.5 font-body text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+          Voltar para atendimentos
+        </Link>
+
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="font-body text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Edição SOAP
+            </p>
+            <h1 className="font-display text-[30px] font-bold leading-tight text-foreground sm:text-[36px]">
+              Editar atendimento
+            </h1>
+            <p className="mt-1 font-body text-[14px] text-muted-foreground">
+              Ajuste data, status e o registro clínico do atendimento.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2 self-start rounded-full bg-primary-soft px-3.5 py-2">
+            <ClipboardEdit className="h-4 w-4 text-primary" />
+            <span className="font-body text-[12px] font-semibold text-primary-soft-fg">
+              {clinicalSession.patient.name} •{' '}
+              {AREA_LABELS[clinicalSession.patient.area] ?? clinicalSession.patient.area}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <SessionForm
+        mode="edit"
+        patient={{
+          id: clinicalSession.patient.id,
+          name: clinicalSession.patient.name,
+          area: clinicalSession.patient.area,
+        }}
+        initialValues={{
+          id: clinicalSession.id,
+          date: clinicalSession.date,
+          duration: clinicalSession.duration,
+          type: clinicalSession.type,
+          status: clinicalSession.status,
+          subjective: clinicalSession.subjective,
+          objective: clinicalSession.objective,
+          assessment: clinicalSession.assessment,
+          plan: clinicalSession.plan,
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/agenda/AgendaViewToggle.tsx
+++ b/src/components/agenda/AgendaViewToggle.tsx
@@ -1,0 +1,58 @@
+import Link from 'next/link'
+import { CalendarDays, List } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface AgendaViewToggleProps {
+  view: 'list' | 'calendar'
+  domiciliar: boolean
+  month?: string
+}
+
+function buildHref(view: 'list' | 'calendar', domiciliar: boolean, month?: string) {
+  const params = new URLSearchParams()
+  if (view === 'calendar') params.set('view', 'calendar')
+  if (domiciliar) params.set('domiciliar', '1')
+  if (view === 'calendar' && month) params.set('month', month)
+  const query = params.toString()
+  return query ? `/agenda?${query}` : '/agenda'
+}
+
+export function AgendaViewToggle({ view, domiciliar, month }: AgendaViewToggleProps) {
+  const options: Array<{
+    value: 'list' | 'calendar'
+    label: string
+    icon: typeof List
+  }> = [
+    { value: 'list', label: 'Lista', icon: List },
+    { value: 'calendar', label: 'Calendário', icon: CalendarDays },
+  ]
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Visualização da agenda"
+      className="inline-flex items-center gap-1 rounded-xl border border-border bg-card p-1"
+    >
+      {options.map(({ value, label, icon: Icon }) => {
+        const active = view === value
+        return (
+          <Link
+            key={value}
+            href={buildHref(value, domiciliar, month)}
+            role="tab"
+            aria-selected={active}
+            className={cn(
+              'flex items-center gap-1.5 rounded-lg px-3 py-1.5 font-body text-[12.5px] font-semibold transition-colors duration-[180ms] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              active
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/agenda/DomiciliarToggle.tsx
+++ b/src/components/agenda/DomiciliarToggle.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePathname, useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useTransition } from 'react'
 import { Home, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -12,10 +12,18 @@ interface DomiciliarToggleProps {
 export function DomiciliarToggle({ active }: DomiciliarToggleProps) {
   const router = useRouter()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const [isPending, startTransition] = useTransition()
 
   function toggle() {
-    const next = active ? pathname : `${pathname}?domiciliar=1`
+    const params = new URLSearchParams(searchParams.toString())
+    if (active) {
+      params.delete('domiciliar')
+    } else {
+      params.set('domiciliar', '1')
+    }
+    const query = params.toString()
+    const next = query ? `${pathname}?${query}` : pathname
     startTransition(() => {
       router.push(next)
     })

--- a/src/components/agenda/MonthCalendar.tsx
+++ b/src/components/agenda/MonthCalendar.tsx
@@ -1,0 +1,276 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { ChevronLeft, ChevronRight, Home } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { SessionCard } from '@/components/sessions/SessionCard'
+
+type CalendarSession = {
+  id: string
+  date: Date | string
+  duration: number
+  type: 'PRESENTIAL' | 'HOME_CARE'
+  status: 'AGENDADO' | 'REALIZADO' | 'CANCELADO'
+  subjective?: string | null
+  objective?: string | null
+  assessment?: string | null
+  plan?: string | null
+  patient: {
+    id: string
+    name: string
+    area?: string
+    homeCarePriority?: string | null
+    address?: string | null
+    neighborhood?: string | null
+    city?: string | null
+  }
+}
+
+interface MonthCalendarProps {
+  monthKey: string
+  todayKey: string
+  domiciliar: boolean
+  sessionsByDay: Record<string, CalendarSession[]>
+}
+
+const WEEKDAY_LABELS = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb']
+
+const STATUS_COLORS: Record<string, string> = {
+  AGENDADO: 'bg-primary',
+  REALIZADO: 'bg-emerald-500',
+  CANCELADO: 'bg-muted-foreground/40',
+}
+
+function pad(value: number) {
+  return String(value).padStart(2, '0')
+}
+
+function buildMonthGrid(monthKey: string) {
+  const [yearStr, monthStr] = monthKey.split('-')
+  const year = Number(yearStr)
+  const monthIndex = Number(monthStr) - 1
+
+  const firstOfMonth = new Date(Date.UTC(year, monthIndex, 1))
+  const startWeekday = firstOfMonth.getUTCDay()
+  const gridStart = new Date(firstOfMonth)
+  gridStart.setUTCDate(firstOfMonth.getUTCDate() - startWeekday)
+
+  const days: Array<{ key: string; day: number; isCurrentMonth: boolean }> = []
+  for (let i = 0; i < 42; i++) {
+    const cell = new Date(gridStart)
+    cell.setUTCDate(gridStart.getUTCDate() + i)
+    const cellYear = cell.getUTCFullYear()
+    const cellMonth = cell.getUTCMonth()
+    days.push({
+      key: `${cellYear}-${pad(cellMonth + 1)}-${pad(cell.getUTCDate())}`,
+      day: cell.getUTCDate(),
+      isCurrentMonth: cellMonth === monthIndex,
+    })
+  }
+
+  return days
+}
+
+function formatMonthLabel(monthKey: string) {
+  const [yearStr, monthStr] = monthKey.split('-')
+  const date = new Date(Date.UTC(Number(yearStr), Number(monthStr) - 1, 1))
+  const label = new Intl.DateTimeFormat('pt-BR', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date)
+  return label.charAt(0).toUpperCase() + label.slice(1)
+}
+
+function shiftMonth(monthKey: string, delta: number) {
+  const [yearStr, monthStr] = monthKey.split('-')
+  const date = new Date(Date.UTC(Number(yearStr), Number(monthStr) - 1 + delta, 1))
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}`
+}
+
+function buildHref(month: string, domiciliar: boolean) {
+  const params = new URLSearchParams()
+  params.set('view', 'calendar')
+  params.set('month', month)
+  if (domiciliar) params.set('domiciliar', '1')
+  return `/agenda?${params.toString()}`
+}
+
+export function MonthCalendar({
+  monthKey,
+  todayKey,
+  domiciliar,
+  sessionsByDay,
+}: MonthCalendarProps) {
+  const days = useMemo(() => buildMonthGrid(monthKey), [monthKey])
+  const monthLabel = useMemo(() => formatMonthLabel(monthKey), [monthKey])
+  const previousMonth = useMemo(() => shiftMonth(monthKey, -1), [monthKey])
+  const nextMonth = useMemo(() => shiftMonth(monthKey, 1), [monthKey])
+
+  const defaultSelected = useMemo(() => {
+    if (sessionsByDay[todayKey]?.length && days.some((d) => d.key === todayKey)) {
+      return todayKey
+    }
+    const firstWithSessions = days.find((d) => d.isCurrentMonth && sessionsByDay[d.key]?.length)
+    if (firstWithSessions) return firstWithSessions.key
+    const firstCurrent = days.find((d) => d.isCurrentMonth)
+    return firstCurrent?.key ?? days[0]?.key ?? null
+  }, [days, sessionsByDay, todayKey])
+
+  const [selectedKey, setSelectedKey] = useState<string | null>(defaultSelected)
+  const selectedSessions = selectedKey ? (sessionsByDay[selectedKey] ?? []) : []
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[1.4fr_1fr]">
+      <section className="rounded-[20px] border border-border bg-card p-4 shadow-sm sm:p-5">
+        <div className="flex items-center justify-between gap-3">
+          <Link
+            href={buildHref(previousMonth, domiciliar)}
+            aria-label="Mês anterior"
+            className="flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Link>
+          <p className="font-display text-[18px] font-bold text-foreground">{monthLabel}</p>
+          <Link
+            href={buildHref(nextMonth, domiciliar)}
+            aria-label="Próximo mês"
+            className="flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Link>
+        </div>
+
+        <div className="mt-4 grid grid-cols-7 gap-1 font-body text-[10.5px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+          {WEEKDAY_LABELS.map((label) => (
+            <div key={label} className="px-1 py-1.5 text-center">
+              {label}
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-1 grid grid-cols-7 gap-1">
+          {days.map((day) => {
+            const sessions = sessionsByDay[day.key] ?? []
+            const total = sessions.length
+            const hasHomeCare = sessions.some((s) => s.type === 'HOME_CARE')
+            const isToday = day.key === todayKey
+            const isSelected = day.key === selectedKey
+
+            return (
+              <button
+                key={day.key}
+                type="button"
+                onClick={() => setSelectedKey(day.key)}
+                aria-pressed={isSelected}
+                className={cn(
+                  'group relative flex min-h-[72px] flex-col items-stretch gap-1 rounded-xl border px-1.5 py-1.5 text-left transition-colors duration-[150ms] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:min-h-[88px] sm:px-2',
+                  isSelected
+                    ? 'border-primary bg-primary-soft'
+                    : 'border-transparent hover:border-border hover:bg-muted/60',
+                  !day.isCurrentMonth && 'opacity-45'
+                )}
+              >
+                <div className="flex items-center justify-between">
+                  <span
+                    className={cn(
+                      'font-body text-[12px] font-semibold',
+                      isToday
+                        ? 'flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground'
+                        : 'text-foreground'
+                    )}
+                  >
+                    {day.day}
+                  </span>
+                  {hasHomeCare ? (
+                    <Home
+                      className="h-3 w-3 text-accent"
+                      strokeWidth={2}
+                      aria-label="Inclui domiciliar"
+                    />
+                  ) : null}
+                </div>
+
+                {total > 0 ? (
+                  <div className="flex flex-col gap-0.5">
+                    <div className="flex flex-wrap gap-0.5">
+                      {sessions.slice(0, 4).map((s) => (
+                        <span
+                          key={s.id}
+                          className={cn(
+                            'h-1.5 w-1.5 rounded-full',
+                            STATUS_COLORS[s.status] ?? 'bg-primary'
+                          )}
+                          aria-hidden
+                        />
+                      ))}
+                    </div>
+                    <span className="font-body text-[10.5px] font-semibold text-muted-foreground">
+                      {total} {total === 1 ? 'sessão' : 'sessões'}
+                    </span>
+                  </div>
+                ) : null}
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1.5 font-body text-[11px] text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-primary" />
+            Agendado
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-emerald-500" />
+            Realizado
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-muted-foreground/40" />
+            Cancelado
+          </span>
+          <span className="flex items-center gap-1.5">
+            <Home className="h-3 w-3 text-accent" />
+            Domiciliar
+          </span>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="rounded-[20px] border border-border bg-card p-4 shadow-sm sm:p-5">
+          <p className="font-body text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Dia selecionado
+          </p>
+          <p className="mt-1 font-display text-[18px] font-bold text-foreground">
+            {selectedKey ? formatSelectedLabel(selectedKey) : 'Selecione um dia'}
+          </p>
+          <p className="mt-1 font-body text-[12.5px] text-muted-foreground">
+            {selectedSessions.length === 0
+              ? 'Sem atendimentos neste dia.'
+              : `${selectedSessions.length} ${selectedSessions.length === 1 ? 'atendimento' : 'atendimentos'}.`}
+          </p>
+        </div>
+
+        {selectedSessions.length > 0 ? (
+          <div className="space-y-3">
+            {selectedSessions.map((s) => (
+              <SessionCard key={s.id} session={s} allowStatusActions showAddress={domiciliar} />
+            ))}
+          </div>
+        ) : null}
+      </section>
+    </div>
+  )
+}
+
+function formatSelectedLabel(dayKey: string) {
+  const [yearStr, monthStr, dayStr] = dayKey.split('-')
+  const date = new Date(Date.UTC(Number(yearStr), Number(monthStr) - 1, Number(dayStr)))
+  const label = new Intl.DateTimeFormat('pt-BR', {
+    timeZone: 'UTC',
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  }).format(date)
+  return label.charAt(0).toUpperCase() + label.slice(1)
+}

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useTransition } from 'react'
-import { CalendarDays, Check, Clock3, Home, MapPin, UserRound, X } from 'lucide-react'
+import { CalendarDays, Check, Clock3, Home, MapPin, Pencil, UserRound, X } from 'lucide-react'
 import type { SessionStatus, SessionType } from '@/generated/prisma/client'
 import { formatDateLongPtBr, formatTimePtBr } from '@/lib/date'
 import { cn } from '@/lib/utils'
@@ -183,6 +183,14 @@ export function SessionCard({
               </button>
             </>
           ) : null}
+
+          <Link
+            href={`/atendimentos/${session.id}/editar`}
+            className="flex items-center justify-center gap-2 rounded-xl border border-border px-4 py-2.5 font-body text-[13px] font-semibold text-foreground transition-colors duration-[180ms] hover:border-primary/40 hover:bg-primary-soft"
+          >
+            <Pencil className="h-4 w-4" />
+            Editar SOAP
+          </Link>
 
           <Link
             href={`/pacientes/${session.patient.id}`}

--- a/src/components/sessions/SessionForm.tsx
+++ b/src/components/sessions/SessionForm.tsx
@@ -5,15 +5,30 @@ import { useRouter } from 'next/navigation'
 import { formatDateTimeLocalInputValue } from '@/lib/date'
 import { cn } from '@/lib/utils'
 
+type SessionStatus = 'AGENDADO' | 'REALIZADO' | 'CANCELADO'
+type SessionType = 'PRESENTIAL' | 'HOME_CARE'
+
 interface SessionFormData {
   date: string
   duration: string
-  type: 'PRESENTIAL' | 'HOME_CARE'
-  status: 'AGENDADO' | 'REALIZADO'
+  type: SessionType
+  status: SessionStatus
   subjective: string
   objective: string
   assessment: string
   plan: string
+}
+
+export interface SessionFormInitialValues {
+  id: string
+  date: Date | string
+  duration: number
+  type: SessionType
+  status: SessionStatus
+  subjective?: string | null
+  objective?: string | null
+  assessment?: string | null
+  plan?: string | null
 }
 
 interface SessionFormProps {
@@ -22,17 +37,25 @@ interface SessionFormProps {
     name: string
     area: string
   }
+  mode?: 'create' | 'edit'
+  initialValues?: SessionFormInitialValues
 }
 
-const sessionTypeOptions = [
+const sessionTypeOptions: Array<{ value: SessionType; label: string }> = [
   { value: 'PRESENTIAL', label: 'Presencial' },
   { value: 'HOME_CARE', label: 'Domiciliar' },
-] as const
+]
 
-const sessionStatusOptions = [
+const createStatusOptions: Array<{ value: SessionStatus; label: string }> = [
   { value: 'AGENDADO', label: 'Agendado' },
   { value: 'REALIZADO', label: 'Realizado' },
-] as const
+]
+
+const editStatusOptions: Array<{ value: SessionStatus; label: string }> = [
+  { value: 'AGENDADO', label: 'Agendado' },
+  { value: 'REALIZADO', label: 'Realizado' },
+  { value: 'CANCELADO', label: 'Cancelado' },
+]
 
 const soapSections = [
   {
@@ -67,6 +90,35 @@ function buildDefaultDate() {
   return formatDateTimeLocalInputValue(date)
 }
 
+function buildInitialFormData(
+  patient: SessionFormProps['patient'],
+  initialValues?: SessionFormInitialValues
+): SessionFormData {
+  if (initialValues) {
+    return {
+      date: formatDateTimeLocalInputValue(new Date(initialValues.date)),
+      duration: String(initialValues.duration),
+      type: initialValues.type,
+      status: initialValues.status,
+      subjective: initialValues.subjective ?? '',
+      objective: initialValues.objective ?? '',
+      assessment: initialValues.assessment ?? '',
+      plan: initialValues.plan ?? '',
+    }
+  }
+
+  return {
+    date: buildDefaultDate(),
+    duration: '50',
+    type: patient.area === 'HOME_CARE' ? 'HOME_CARE' : 'PRESENTIAL',
+    status: 'AGENDADO',
+    subjective: '',
+    objective: '',
+    assessment: '',
+    plan: '',
+  }
+}
+
 function Field({
   label,
   error,
@@ -94,21 +146,16 @@ const inputClass = cn(
   'transition-colors duration-[180ms]'
 )
 
-export function SessionForm({ patient }: SessionFormProps) {
+export function SessionForm({ patient, mode = 'create', initialValues }: SessionFormProps) {
   const router = useRouter()
-  const [form, setForm] = useState<SessionFormData>({
-    date: buildDefaultDate(),
-    duration: '50',
-    type: patient.area === 'HOME_CARE' ? 'HOME_CARE' : 'PRESENTIAL',
-    status: 'AGENDADO',
-    subjective: '',
-    objective: '',
-    assessment: '',
-    plan: '',
-  })
+  const isEdit = mode === 'edit' && initialValues
+  const [form, setForm] = useState<SessionFormData>(() =>
+    buildInitialFormData(patient, initialValues)
+  )
   const [errors, setErrors] = useState<Partial<Record<keyof SessionFormData, string>>>({})
   const [serverError, setServerError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const statusOptions = isEdit ? editStatusOptions : createStatusOptions
 
   function set<K extends keyof SessionFormData>(key: K, value: SessionFormData[K]) {
     setForm((previous) => ({ ...previous, [key]: value }))
@@ -121,15 +168,28 @@ export function SessionForm({ patient }: SessionFormProps) {
     setIsLoading(true)
 
     try {
-      const response = await fetch('/api/sessions', {
-        method: 'POST',
+      const url = isEdit ? `/api/sessions/${initialValues.id}` : '/api/sessions'
+      const method = isEdit ? 'PUT' : 'POST'
+
+      const body: Record<string, unknown> = {
+        date: new Date(form.date).toISOString(),
+        duration: Number(form.duration),
+        type: form.type,
+        status: form.status,
+        subjective: form.subjective,
+        objective: form.objective,
+        assessment: form.assessment,
+        plan: form.plan,
+      }
+
+      if (!isEdit) {
+        body.patientId = patient.id
+      }
+
+      const response = await fetch(url, {
+        method,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          ...form,
-          patientId: patient.id,
-          date: new Date(form.date).toISOString(),
-          duration: Number(form.duration),
-        }),
+        body: JSON.stringify(body),
       })
 
       const data = await response.json()
@@ -157,6 +217,14 @@ export function SessionForm({ patient }: SessionFormProps) {
     }
   }
 
+  const submitLabel = isEdit
+    ? isLoading
+      ? 'Salvando...'
+      : 'Salvar alterações'
+    : isLoading
+      ? 'Salvando...'
+      : 'Salvar atendimento'
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6 sm:space-y-8">
       {serverError ? (
@@ -172,7 +240,9 @@ export function SessionForm({ patient }: SessionFormProps) {
               Dados do atendimento
             </h2>
             <p className="mt-1 font-body text-[13px] text-muted-foreground">
-              Registre data, duração, tipo e status inicial da sessão.
+              {isEdit
+                ? 'Atualize data, duração, tipo e status do atendimento.'
+                : 'Registre data, duração, tipo e status inicial da sessão.'}
             </p>
           </div>
           <div className="rounded-full bg-primary-soft px-3 py-1.5 font-body text-[11px] font-semibold text-primary-soft-fg">
@@ -205,7 +275,7 @@ export function SessionForm({ patient }: SessionFormProps) {
             <select
               className={inputClass}
               value={form.type}
-              onChange={(event) => set('type', event.target.value as SessionFormData['type'])}
+              onChange={(event) => set('type', event.target.value as SessionType)}
             >
               {sessionTypeOptions.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -219,9 +289,9 @@ export function SessionForm({ patient }: SessionFormProps) {
             <select
               className={inputClass}
               value={form.status}
-              onChange={(event) => set('status', event.target.value as SessionFormData['status'])}
+              onChange={(event) => set('status', event.target.value as SessionStatus)}
             >
-              {sessionStatusOptions.map((option) => (
+              {statusOptions.map((option) => (
                 <option key={option.value} value={option.value}>
                   {option.label}
                 </option>
@@ -288,7 +358,7 @@ export function SessionForm({ patient }: SessionFormProps) {
           disabled={isLoading}
           className="w-full rounded-xl bg-primary px-6 py-2.5 font-body text-[13px] font-semibold text-primary-foreground shadow-glow transition-colors duration-[180ms] hover:bg-primary-hover disabled:opacity-50 sm:w-auto"
         >
-          {isLoading ? 'Salvando...' : 'Salvar atendimento'}
+          {submitLabel}
         </button>
       </div>
     </form>

--- a/src/server/modules/sessions/http/session.dto.ts
+++ b/src/server/modules/sessions/http/session.dto.ts
@@ -53,7 +53,7 @@ export const listSessionsDTO = z.object({
   from: optionalDateTimeString,
   to: optionalDateTimeString,
   page: z.coerce.number().int().min(1).default(1),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+  limit: z.coerce.number().int().min(1).max(500).default(20),
 })
 
 export type CreateSessionDTO = z.infer<typeof createSessionDTO>


### PR DESCRIPTION
## Resumo

Phase 10 fecha o ciclo clínico interno antes das integrações externas: agora o
fisioterapeuta pode revisar/atualizar o SOAP de qualquer atendimento existente e
enxergar a agenda em formato mensal, sem perder a listagem atual.

- `SessionForm` refatorado para suportar `mode="create" | "edit"` com `initialValues`
- Nova rota `/atendimentos/[id]/editar` carrega a sessão e persiste via `PUT /api/sessions/:id`
- Botão **Editar SOAP** no `SessionCard` apontando para a nova rota
- Visão `/agenda?view=calendar&month=YYYY-MM` com calendário mensal e painel lateral
  de sessões do dia selecionado
- `AgendaViewToggle` (Lista / Calendário) preservando filtro domiciliar e mês corrente
- `DomiciliarToggle` agora preserva os demais query params ao alternar visão
- Limite máximo de `listSessionsDTO` elevado de 100 → 500 para suportar a visão mensal

## Mudanças principais

| Arquivo | Mudança |
| --- | --- |
| `src/components/sessions/SessionForm.tsx` | Modo create/edit + opção `CANCELADO` em edição |
| `src/app/(app)/atendimentos/[id]/editar/page.tsx` | Nova página de edição (server component) |
| `src/components/sessions/SessionCard.tsx` | Botão "Editar SOAP" |
| `src/components/agenda/AgendaViewToggle.tsx` | Tabs Lista / Calendário |
| `src/components/agenda/MonthCalendar.tsx` | Grid 6×7, navegação de mês, indicadores por status, painel do dia |
| `src/components/agenda/DomiciliarToggle.tsx` | Preserva demais params na URL |
| `src/app/(app)/agenda/page.tsx` | Suporte a `view=list` e `view=calendar` |
| `src/server/modules/sessions/http/session.dto.ts` | `limit` máximo 100 → 500 |

## Regras de domínio mantidas

- Sessão `AGENDADO` continua não podendo ser salva no passado
- Edição usa `PUT /api/sessions/:id` existente, sem mudar contrato
- Multi-tenant por `userId` preservado (`getSessionUseCase` filtra por usuário)

## Test plan

- [ ] `/atendimentos` mostra botão **Editar SOAP** em cada card
- [ ] `/atendimentos/[id]/editar` carrega data, duração, tipo, status e campos SOAP preenchidos
- [ ] Salvar alteração SOAP persiste e aparece na timeline (`/pacientes/:id/evolucao`)
- [ ] Tentar salvar sessão `AGENDADO` no passado é bloqueado pelo backend
- [ ] `/agenda` (default) continua exibindo listagem agrupada por dia
- [ ] `/agenda?view=calendar` exibe o mês atual com contagem de sessões por dia
- [ ] Navegação ⟵ / ⟶ troca de mês sem perder filtro domiciliar
- [ ] Clicar em um dia mostra os atendimentos do dia no painel lateral (desktop) ou abaixo (mobile)
- [ ] Toggle Lista ⇄ Calendário preserva `domiciliar=1` quando ativo
- [ ] Toggle Domiciliar preserva `view=calendar` e `month` ao alternar
- [ ] `npm run build` passa
- [ ] Layout responsivo em mobile (calendário não causa overflow)

## Notas

- 4 erros pré-existentes do `npm run lint` permanecem (em `documentos/page.tsx` e
  `api/documents/[id]/download/route.ts`); não são introduzidos por esta PR.
- `ENCAMINHAMENTO` segue como card "em breve" (decisão da Phase 9).
- Próxima fase planejada: Phase 11 — E-mails com Gmail App Password.