### PR TITLE
feat: phase 14 — Locais de Trabalho e Modalidade de Atendimento

### DIFF
--- a/.docs/CHANGELOG.md
+++ b/.docs/CHANGELOG.md
@@ -9,6 +9,26 @@ e o projeto segue [Conventional Commits](https://www.conventionalcommits.org/) e
 
 ### Added
 
+- **Phase 14 — Locais de Trabalho**
+  - Enum `WorkplaceKind` (`OWN_CLINIC`, `PARTNER_CLINIC`, `PARTICULAR`, `ONLINE`)
+  - Enum `AttendanceType` (`CLINIC`, `HOME_CARE`, `HOSPITAL`, `CORPORATE`, `ONLINE`)
+  - Modelo `Workplace` no schema Prisma com `defaultAttendanceType`, `defaultSessionPrice`,
+    `defaultCommissionPct`, `address`, `notes` e `isActive`
+  - `Session.workplaceId` (nullable) e `Session.attendanceType` (nullable)
+  - Migration `phase14_workplaces` com backfill SQL: 1 workplace default por usuário e
+    vinculação automática de todas as sessões existentes
+  - Módulo `workplaces` completo: `domain/`, `http/`, `infra/`, `application/` com
+    create, list, get, update e archive; testes unitários incluídos
+  - `POST/GET /api/workplaces` e `GET/PUT/DELETE /api/workplaces/:id`
+  - Página `/configuracoes/locais` com lista e CRUD inline (`WorkplacesManager`,
+    `WorkplaceCard`, `WorkplaceForm`)
+  - `SessionForm` com seletor de workplace (popula attendanceType default) e seletor de
+    modalidade (`AttendanceType`)
+  - `SessionCard` exibe nome do local de trabalho abaixo do horário
+  - Link "Locais" na sidebar (secundário, com ícone `MapPin`)
+  - Seed demo com "Clínica Movimento" (OWN_CLINIC) e "Atendimento Particular" (PARTICULAR)
+  - `createSessionUseCase` busca workplace default do usuário quando `workplaceId` omitido
+
 - **Phase 13 — Polimento de UI e Componentes**
   - Componente `ThemedSelect` (`src/components/ui/themed-select.tsx`): select customizado
     com botão trigger, lista flutuante, checkmark no item ativo, hover/focus na paleta

--- a/.docs/CONTEXT.md
+++ b/.docs/CONTEXT.md
@@ -4,6 +4,16 @@
 
 ## Fase Atual
 
+**Phase 14 — Locais de Trabalho concluída**
+Enum `WorkplaceKind` (`OWN_CLINIC`, `PARTNER_CLINIC`, `PARTICULAR`, `ONLINE`) e enum
+`AttendanceType` (`CLINIC`, `HOME_CARE`, `HOSPITAL`, `CORPORATE`, `ONLINE`) adicionados.
+Modelo `Workplace` criado; `Session` ganhou `workplaceId` e `attendanceType` (nullable).
+Migration `phase14_workplaces` com backfill SQL: 1 workplace default por usuário + sessões
+vinculadas. Módulo `workplaces` completo (domain, dto, infra, application). CRUD REST em
+`/api/workplaces`. Página `/configuracoes/locais`. `SessionForm` seleciona workplace e
+modalidade; `SessionCard` exibe nome do local. Sidebar com link "Locais". Seed demo com
+"Clínica Movimento" e "Atendimento Particular".
+
 **Phase 13 — Polimento de UI e Componentes concluída**
 `ThemedSelect` e `DateTimePicker` temáticos substituem todos os controles nativos do navegador.
 `SessionCard` refatorado com menu flutuante `...` (Confirmar exposto, demais ações no menu).
@@ -44,33 +54,19 @@ Campos de endereço e prioridade no modelo `Patient`, seção de logística na f
 
 ## Próximo Passo Planejado
 
-**Ciclo "Multi-modalidade + Financeiro" planejado** — [ADR-005](decisions/ADR-005-multi-modalidade-financeiro.md)
-desacopla área do paciente (passa para `TreatmentPlan`), introduz locais de trabalho
-(`Workplace`) e adiciona acompanhamento financeiro (`Payment`, `expectedFee`, dashboard).
+**Phase 15 — Plano de Tratamento** — [task file](tasks/phase-15-treatment-plans.md)
+Modelo `TreatmentPlan` (1 paciente → N planos), expansão de `TherapyArea`, novo enum
+`Specialty`. Backfill cria plano legado por paciente. Remove `Patient.area` e
+`Session.type` (campos legados que coexistiram com os novos desde a Phase 14).
 
-Sequência:
+Sequência restante do ciclo "Multi-modalidade + Financeiro":
+- **Phase 16** — [Pagamentos](tasks/phase-16-payments.md)
+- **Phase 17** — [Dashboard financeiro](tasks/phase-17-finance-dashboard.md)
 
-- **Phase 14** — [Locais de trabalho](tasks/phase-14-workplaces.md): modelo `Workplace`,
-  `Session.workplaceId` e `Session.attendanceType`. Backfill: 1 workplace default por
-  usuário. Mantém `Patient.area` e `Session.type` por compatibilidade.
-- **Phase 15** — [Plano de tratamento](tasks/phase-15-treatment-plans.md): modelo
-  `TreatmentPlan` (1 paciente → N planos), expansão de `TherapyArea`, novo enum
-  `Specialty`. Backfill cria plano legado por paciente. Remove `Patient.area` e
-  `Session.type`.
-- **Phase 16** — [Pagamentos](tasks/phase-16-payments.md): modelo `Payment`,
-  `Session.expectedFee` snapshot, `Session.paymentStatus` cache, modal de registrar
-  pagamento, saldo do plano (avulso ou pacote).
-- **Phase 17** — [Dashboard financeiro](tasks/phase-17-finance-dashboard.md): página
-  `/financeiro` com recebido vs previsto, série temporal, breakdowns por local e por
-  área, lista de pendências.
-
-Antes de iniciar Phase 14, ainda pendente da janela anterior:
-
+Pendências operacionais:
 - Validar integrações em ambiente real (Phase 11/12) e preparar deploy na Vercel
 - Configurar `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALENDAR_REDIRECT_URI`
   e `INTEGRATION_ENCRYPTION_KEY` (esta última gerada com `openssl rand -base64 32`)
-- Decisão registrada: `ENCAMINHAMENTO` segue apenas como card "em breve" em `/documentos`.
-  Caso o usuário aprove gerar PDF, criar enum, migration, DTO e template em iteração futura.
 
 ## O Que Existe
 
@@ -89,7 +85,6 @@ Antes de iniciar Phase 14, ainda pendente da janela anterior:
 
 ### Tasks planejadas
 
-- `.docs/tasks/phase-14-workplaces.md` — Locais de trabalho e desacoplamento de atendimento
 - `.docs/tasks/phase-15-treatment-plans.md` — Plano de tratamento e multi-modalidade
 - `.docs/tasks/phase-16-payments.md` — Pagamentos e cobrança (avulso e pacote)
 - `.docs/tasks/phase-17-finance-dashboard.md` — Dashboard financeiro (recebido vs previsto)
@@ -98,6 +93,7 @@ Antes de iniciar Phase 14, ainda pendente da janela anterior:
 
 ### Tasks já concluídas (referência)
 
+- `.docs/tasks/phase-14-workplaces.md` — Locais de trabalho (`Workplace`, `AttendanceType`, CRUD + UI)
 - `.docs/tasks/phase-9-ux-polish.md` — Polimentos visuais e de microinteração
 - `.docs/tasks/phase-10-clinical-agenda-flow.md` — Edição SOAP e visualização mensal da agenda
 - `.docs/tasks/phase-11-email-notifications.md` — Gmail App Password e envios
@@ -195,6 +191,7 @@ Antes de iniciar Phase 14, ainda pendente da janela anterior:
 - `Document` — metadados do documento gerado (tipo, título, período, patientId, userId), `isActive`
 - `CalendarConnection` — conexão Google Calendar por usuário, com tokens criptografados e agenda padrão
 - `CalendarEventLink` — vínculo entre uma sessão e um evento externo Google Calendar
+- `Workplace` — local de trabalho do fisioterapeuta (OWN_CLINIC, PARTNER_CLINIC, PARTICULAR, ONLINE)
 
 ## Realidade Arquitetural Atual
 
@@ -207,6 +204,7 @@ Módulo `patients` segue a mesma estrutura em `src/server/modules/patients/`
 Módulo `sessions` segue o mesmo padrão em `src/server/modules/sessions/`
 Módulo `documents` segue o mesmo padrão em `src/server/modules/documents/`
 Módulo `calendar` segue o mesmo padrão em `src/server/modules/calendar/`
+Módulo `workplaces` segue o mesmo padrão em `src/server/modules/workplaces/`
 
 ## Pendências Conhecidas
 

--- a/.docs/tasks/phase-14-workplaces.md
+++ b/.docs/tasks/phase-14-workplaces.md
@@ -2,9 +2,7 @@
 
 ## Status
 
-- [ ] Todo
-- [ ] In Progress
-- [ ] Done
+- [x] Done
 
 ## Contexto
 

--- a/README.md
+++ b/README.md
@@ -192,14 +192,16 @@ Após o seed:
   PhysioFlow → Google Calendar)
 - Phase 13 — Polimento de UI e Componentes (`ThemedSelect`, `DateTimePicker`, refatoração
   do `SessionCard` com menu flutuante, correção do sidebar mobile, remoção de emoji no dashboard)
+- Phase 14 — Locais de Trabalho (modelo `Workplace`, enums `WorkplaceKind`/`AttendanceType`,
+  migration com backfill, CRUD `/configuracoes/locais`, seletor de local e modalidade no
+  `SessionForm`, nome do local no `SessionCard`)
 
 ### 🗺️ Planejado — Ciclo "Multi-modalidade + Financeiro"
 
 > Decisão arquitetural: [ADR-005](.docs/decisions/ADR-005-multi-modalidade-financeiro.md)
 
-- **Phase 14 — Locais de Trabalho** (`Workplace`, `Session.workplaceId`, `attendanceType`)
 - **Phase 15 — Plano de Tratamento** (multi-modalidade por paciente, remoção do
-  `Patient.area`, expansão de `TherapyArea`, novo enum `Specialty`)
+  `Patient.area` e `Session.type`, expansão de `TherapyArea`, novo enum `Specialty`)
 - **Phase 16 — Pagamentos** (`Payment`, `expectedFee` snapshot, avulso e pacote,
   saldo do plano)
 - **Phase 17 — Dashboard Financeiro** (recebido vs previsto, série temporal,
@@ -207,10 +209,9 @@ Após o seed:
 
 ### ➡️ Próximo Passo
 
-Iniciar **Phase 14**: criar modelo `Workplace`, migration `phase14_workplaces` com
-backfill (1 workplace default por usuário), página `/configuracoes/locais` e seletor de
-local + tipo de atendimento no formulário de sessão.
+Iniciar **Phase 15**: modelo `TreatmentPlan` (1 paciente → N planos), backfill que cria
+plano legado por paciente, expansão de `TherapyArea`, novo enum `Specialty`. Remove
+`Patient.area` e `Session.type` (campos mantidos em coexistência desde a Phase 14).
 
-Em paralelo, ainda pendente do ciclo anterior: aplicar as migrations atuais no Neon com
-`npx prisma migrate deploy`, configurar as variáveis de e-mail/Google na Vercel e
+Ainda pendente do ciclo anterior: configurar as variáveis de e-mail/Google na Vercel e
 validar os fluxos reais de envio e sincronização.

--- a/prisma/migrations/20260425170509_phase14_workplaces/migration.sql
+++ b/prisma/migrations/20260425170509_phase14_workplaces/migration.sql
@@ -1,0 +1,78 @@
+-- CreateEnum
+CREATE TYPE "WorkplaceKind" AS ENUM ('OWN_CLINIC', 'PARTNER_CLINIC', 'PARTICULAR', 'ONLINE');
+
+-- CreateEnum
+CREATE TYPE "AttendanceType" AS ENUM ('CLINIC', 'HOME_CARE', 'HOSPITAL', 'CORPORATE', 'ONLINE');
+
+-- DropForeignKey
+ALTER TABLE "CalendarEventLink" DROP CONSTRAINT "CalendarEventLink_sessionId_fkey";
+
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN     "attendanceType" "AttendanceType",
+ADD COLUMN     "workplaceId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Workplace" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "kind" "WorkplaceKind" NOT NULL,
+    "defaultAttendanceType" "AttendanceType" NOT NULL,
+    "address" TEXT,
+    "defaultSessionPrice" DECIMAL(10,2),
+    "defaultCommissionPct" DECIMAL(5,2),
+    "notes" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Workplace_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Workplace_userId_idx" ON "Workplace"("userId");
+
+-- CreateIndex
+CREATE INDEX "Workplace_userId_isActive_idx" ON "Workplace"("userId", "isActive");
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_workplaceId_fkey" FOREIGN KEY ("workplaceId") REFERENCES "Workplace"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Workplace" ADD CONSTRAINT "Workplace_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CalendarEventLink" ADD CONSTRAINT "CalendarEventLink_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Backfill: create default workplace for every existing user
+INSERT INTO "Workplace" (id, "userId", name, kind, "defaultAttendanceType", "isActive", "createdAt", "updatedAt")
+SELECT
+  gen_random_uuid()::text,
+  u.id,
+  'Meu consultório',
+  'OWN_CLINIC'::"WorkplaceKind",
+  'CLINIC'::"AttendanceType",
+  true,
+  now(),
+  now()
+FROM "User" u
+WHERE NOT EXISTS (
+  SELECT 1 FROM "Workplace" w WHERE w."userId" = u.id
+);
+
+-- Backfill: link existing sessions to their user's default workplace and set attendanceType
+UPDATE "Session" s
+SET
+  "workplaceId" = w.id,
+  "attendanceType" = CASE s.type
+    WHEN 'HOME_CARE'::"SessionType" THEN 'HOME_CARE'::"AttendanceType"
+    ELSE 'CLINIC'::"AttendanceType"
+  END
+FROM (
+  SELECT DISTINCT ON ("userId") id, "userId"
+  FROM "Workplace"
+  WHERE "isActive" = true
+  ORDER BY "userId", "createdAt" ASC
+) w
+WHERE w."userId" = s."userId"
+  AND s."workplaceId" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,21 @@ enum CalendarSyncStatus {
   REMOVED
 }
 
+enum WorkplaceKind {
+  OWN_CLINIC
+  PARTNER_CLINIC
+  PARTICULAR
+  ONLINE
+}
+
+enum AttendanceType {
+  CLINIC
+  HOME_CARE
+  HOSPITAL
+  CORPORATE
+  ONLINE
+}
+
 model User {
   id        String   @id @default(cuid())
   email     String   @unique
@@ -84,6 +99,7 @@ model User {
   emailMessages       EmailMessage[]
   calendarConnections CalendarConnection[]
   calendarEventLinks  CalendarEventLink[]
+  workplaces          Workplace[]
 }
 
 model Patient {
@@ -135,9 +151,11 @@ model Session {
   patientId  String
   date       DateTime
   duration   Int
-  type       SessionType   @default(PRESENTIAL)
-  status     SessionStatus @default(AGENDADO)
-  isActive   Boolean       @default(true)
+  type           SessionType    @default(PRESENTIAL)
+  status         SessionStatus  @default(AGENDADO)
+  workplaceId    String?
+  attendanceType AttendanceType?
+  isActive       Boolean        @default(true)
   subjective String?
   objective  String?
   assessment String?
@@ -147,6 +165,7 @@ model Session {
 
   user               User                @relation(fields: [userId], references: [id])
   patient            Patient             @relation(fields: [patientId], references: [id])
+  workplace          Workplace?          @relation(fields: [workplaceId], references: [id])
   emailMessages      EmailMessage[]
   calendarEventLinks CalendarEventLink[]
 
@@ -154,6 +173,27 @@ model Session {
   @@index([userId, patientId])
   @@index([userId, date])
   @@index([userId, status])
+  @@index([userId, isActive])
+}
+
+model Workplace {
+  id                    String         @id @default(cuid())
+  userId                String
+  name                  String
+  kind                  WorkplaceKind
+  defaultAttendanceType AttendanceType
+  address               String?
+  defaultSessionPrice   Decimal?       @db.Decimal(10, 2)
+  defaultCommissionPct  Decimal?       @db.Decimal(5, 2)
+  notes                 String?
+  isActive              Boolean        @default(true)
+  createdAt             DateTime       @default(now())
+  updatedAt             DateTime       @updatedAt
+
+  user     User      @relation(fields: [userId], references: [id])
+  sessions Session[]
+
+  @@index([userId])
   @@index([userId, isActive])
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,35 +17,23 @@ async function main() {
   const demoPassword = 'demo1234'
 
   await prisma.session.deleteMany({
-    where: {
-      user: {
-        email: demoEmail,
-      },
-    },
+    where: { user: { email: demoEmail } },
   })
 
   await prisma.clinicalRecord.deleteMany({
-    where: {
-      patient: {
-        user: {
-          email: demoEmail,
-        },
-      },
-    },
+    where: { patient: { user: { email: demoEmail } } },
   })
 
   await prisma.patient.deleteMany({
-    where: {
-      user: {
-        email: demoEmail,
-      },
-    },
+    where: { user: { email: demoEmail } },
+  })
+
+  await prisma.workplace.deleteMany({
+    where: { user: { email: demoEmail } },
   })
 
   await prisma.user.deleteMany({
-    where: {
-      email: demoEmail,
-    },
+    where: { email: demoEmail },
   })
 
   const user = await prisma.user.create({
@@ -118,6 +106,27 @@ async function main() {
     },
   })
 
+  const clinica = await prisma.workplace.create({
+    data: {
+      userId: user.id,
+      name: 'Clínica Movimento',
+      kind: 'OWN_CLINIC',
+      defaultAttendanceType: 'CLINIC',
+      address: 'Rua das Flores, 120 — São Paulo',
+      notes: 'Consultório principal com equipamentos completos.',
+    },
+  })
+
+  const particular = await prisma.workplace.create({
+    data: {
+      userId: user.id,
+      name: 'Atendimento Particular',
+      kind: 'PARTICULAR',
+      defaultAttendanceType: 'HOME_CARE',
+      notes: 'Pacientes atendidos em domicílio.',
+    },
+  })
+
   const now = new Date()
   const daysFromNow = (days: number, hour: number, minute = 0) => {
     const date = new Date(now)
@@ -142,6 +151,8 @@ async function main() {
         duration: 60,
         type: 'PRESENTIAL',
         status: 'REALIZADO',
+        workplaceId: clinica.id,
+        attendanceType: 'CLINIC',
         subjective: 'Paciente relata melhora da dor lombar. EVA 4/10.',
         objective:
           'Teste de Lasègue negativo bilateralmente. Força muscular 4/5 em flexores de tronco.',
@@ -155,6 +166,8 @@ async function main() {
         duration: 60,
         type: 'PRESENTIAL',
         status: 'REALIZADO',
+        workplaceId: clinica.id,
+        attendanceType: 'CLINIC',
         subjective: 'Sem queixas de dor em repouso. Dor leve ao esforço (EVA 2/10).',
         objective: 'Mobilidade lombar em 80% do esperado para a idade. Sem sinais neurológicos.',
         assessment: 'Alta funcional próxima. Considerar espaçamento das sessões.',
@@ -167,6 +180,8 @@ async function main() {
         duration: 50,
         type: 'PRESENTIAL',
         status: 'REALIZADO',
+        workplaceId: clinica.id,
+        attendanceType: 'CLINIC',
         subjective: 'Paciente tolerou bem o treino e relata confiança maior para subir escadas.',
         objective: 'ADM de joelho em 120 graus, sem edema. Controle excêntrico melhorado.',
         assessment: 'Boa progressão pós-LCA. Liberar exercícios funcionais com cautela.',
@@ -179,6 +194,8 @@ async function main() {
         duration: 45,
         type: 'HOME_CARE',
         status: 'AGENDADO',
+        workplaceId: particular.id,
+        attendanceType: 'HOME_CARE',
         subjective: 'Paciente solicita foco em analgesia e mobilidade global.',
         plan: 'Sessão domiciliar com recursos manuais e orientação de exercícios leves.',
       },
@@ -189,6 +206,8 @@ async function main() {
         duration: 50,
         type: 'PRESENTIAL',
         status: 'AGENDADO',
+        workplaceId: clinica.id,
+        attendanceType: 'CLINIC',
         plan: 'Reavaliação funcional e progressão do treino de força.',
       },
       {
@@ -198,6 +217,8 @@ async function main() {
         duration: 60,
         type: 'PRESENTIAL',
         status: 'CANCELADO',
+        workplaceId: clinica.id,
+        attendanceType: 'CLINIC',
         subjective: 'Paciente em viagem, solicitou reagendamento.',
         plan: 'Remarcar após retorno à rotina.',
       },
@@ -207,6 +228,7 @@ async function main() {
   console.log('Seed concluído')
   console.log(`Usuário demo: ${demoEmail} / ${demoPassword}`)
   console.log(`Pacientes: ${gervasio.name}, ${carla.name}, ${rafael.name}`)
+  console.log(`Locais: ${clinica.name}, ${particular.name}`)
 }
 
 main()

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -16,7 +16,19 @@ async function main() {
   const demoEmail = 'demo@phisioflow.com'
   const demoPassword = 'demo1234'
 
+  await prisma.calendarEventLink.deleteMany({
+    where: { user: { email: demoEmail } },
+  })
+
+  await prisma.emailMessage.deleteMany({
+    where: { user: { email: demoEmail } },
+  })
+
   await prisma.session.deleteMany({
+    where: { user: { email: demoEmail } },
+  })
+
+  await prisma.calendarConnection.deleteMany({
     where: { user: { email: demoEmail } },
   })
 
@@ -24,11 +36,19 @@ async function main() {
     where: { patient: { user: { email: demoEmail } } },
   })
 
+  await prisma.document.deleteMany({
+    where: { user: { email: demoEmail } },
+  })
+
   await prisma.patient.deleteMany({
     where: { user: { email: demoEmail } },
   })
 
   await prisma.workplace.deleteMany({
+    where: { user: { email: demoEmail } },
+  })
+
+  await prisma.emailSettings.deleteMany({
     where: { user: { email: demoEmail } },
   })
 

--- a/src/app/(app)/configuracoes/locais/page.tsx
+++ b/src/app/(app)/configuracoes/locais/page.tsx
@@ -1,0 +1,27 @@
+import { getSession } from '@/lib/session'
+import { listWorkplacesUseCase } from '@/server/modules/workplaces/application/list-workplaces'
+import { WorkplacesManager } from '@/components/workplaces/WorkplacesManager'
+
+export default async function LocaisPage() {
+  const session = await getSession()
+  const { workplaces } = await listWorkplacesUseCase(session.userId!, { includeArchived: false })
+
+  return (
+    <div className="space-y-6 sm:space-y-8">
+      <div>
+        <p className="font-body text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          CONFIGURAÇÕES
+        </p>
+        <h1 className="font-display text-[30px] font-bold leading-tight text-foreground sm:text-[36px]">
+          Locais de trabalho
+        </h1>
+        <p className="mt-2 font-body text-[14px] text-muted-foreground">
+          Gerencie os locais onde você atende. Cada atendimento pode ser vinculado a um local
+          específico.
+        </p>
+      </div>
+
+      <WorkplacesManager initialWorkplaces={workplaces} />
+    </div>
+  )
+}

--- a/src/app/api/workplaces/[id]/route.ts
+++ b/src/app/api/workplaces/[id]/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { updateWorkplaceDTO } from '@/server/modules/workplaces/http/workplace.dto'
+import { WorkplaceNotFoundError, getWorkplaceUseCase } from '@/server/modules/workplaces/application/get-workplace'
+import { updateWorkplaceUseCase } from '@/server/modules/workplaces/application/update-workplace'
+import { archiveWorkplaceUseCase } from '@/server/modules/workplaces/application/archive-workplace'
+
+type Params = { params: Promise<{ id: string }> }
+
+export async function GET(_request: Request, { params }: Params) {
+  const session = await getSession()
+
+  if (!session.userId) {
+    return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  try {
+    const workplace = await getWorkplaceUseCase(id, session.userId)
+    return NextResponse.json({ workplace })
+  } catch (error) {
+    if (error instanceof WorkplaceNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ message: 'Erro interno' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: Request, { params }: Params) {
+  const session = await getSession()
+
+  if (!session.userId) {
+    return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+  }
+
+  const { id } = await params
+  const body = await request.json()
+  const parsed = updateWorkplaceDTO.safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json({ errors: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  try {
+    const workplace = await updateWorkplaceUseCase(id, session.userId, parsed.data)
+    return NextResponse.json({ workplace })
+  } catch (error) {
+    if (error instanceof WorkplaceNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ message: 'Erro interno' }, { status: 500 })
+  }
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const session = await getSession()
+
+  if (!session.userId) {
+    return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  try {
+    const workplace = await archiveWorkplaceUseCase(id, session.userId)
+    return NextResponse.json({ workplace })
+  } catch (error) {
+    if (error instanceof WorkplaceNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ message: 'Erro interno' }, { status: 500 })
+  }
+}

--- a/src/app/api/workplaces/route.ts
+++ b/src/app/api/workplaces/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { createWorkplaceDTO, listWorkplacesDTO } from '@/server/modules/workplaces/http/workplace.dto'
+import { createWorkplaceUseCase } from '@/server/modules/workplaces/application/create-workplace'
+import { listWorkplacesUseCase } from '@/server/modules/workplaces/application/list-workplaces'
+
+export async function GET(request: Request) {
+  const session = await getSession()
+
+  if (!session.userId) {
+    return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const parsed = listWorkplacesDTO.safeParse({
+    includeArchived: searchParams.get('includeArchived') ?? undefined,
+  })
+
+  if (!parsed.success) {
+    return NextResponse.json({ errors: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const result = await listWorkplacesUseCase(session.userId, parsed.data)
+  return NextResponse.json(result)
+}
+
+export async function POST(request: Request) {
+  const session = await getSession()
+
+  if (!session.userId) {
+    return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const parsed = createWorkplaceDTO.safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json({ errors: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const workplace = await createWorkplaceUseCase(session.userId, parsed.data)
+  return NextResponse.json({ workplace }, { status: 201 })
+}

--- a/src/components/calendar/GoogleCalendarSettingsCard.tsx
+++ b/src/components/calendar/GoogleCalendarSettingsCard.tsx
@@ -25,12 +25,6 @@ interface GoogleCalendarSettingsCardProps {
   status?: string
 }
 
-const inputClass = cn(
-  'w-full rounded-xl border border-border bg-input px-3.5 py-2.5',
-  'font-body text-[14px] text-foreground',
-  'focus:border-primary focus:outline-none focus:ring-2 focus:ring-ring',
-  'transition-colors duration-[180ms]'
-)
 
 export function GoogleCalendarSettingsCard({
   initialConnection,

--- a/src/components/layout/navigation.ts
+++ b/src/components/layout/navigation.ts
@@ -5,6 +5,7 @@ import {
   FileText,
   HelpCircle,
   LayoutDashboard,
+  MapPin,
   Settings,
   Users,
 } from 'lucide-react'
@@ -24,6 +25,7 @@ export const primaryNavigation: NavigationItem[] = [
 ]
 
 export const secondaryNavigation: NavigationItem[] = [
+  { label: 'Locais', href: '/configuracoes/locais', icon: MapPin },
   { label: 'Configurações', href: '/configuracoes/email', icon: Settings },
   { label: 'Suporte', href: '/suporte', icon: HelpCircle },
 ]

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -36,6 +36,7 @@ interface SessionCardProps {
     objective?: string | null
     assessment?: string | null
     plan?: string | null
+    workplace?: { id: string; name: string } | null
     calendarEventLinks?: Array<{
       id: string
       status: string
@@ -281,6 +282,12 @@ export function SessionCard({
                 <span className="flex items-center gap-1.5">
                   <CalendarDays className="h-3.5 w-3.5" />
                   {formatDateLongPtBr(session.date)}
+                </span>
+              ) : null}
+              {session.workplace ? (
+                <span className="flex items-center gap-1.5">
+                  <MapPin className="h-3.5 w-3.5" />
+                  {session.workplace.name}
                 </span>
               ) : null}
               {showAddress && session.patient.address ? (

--- a/src/components/sessions/SessionForm.tsx
+++ b/src/components/sessions/SessionForm.tsx
@@ -11,12 +11,21 @@ import { ThemedSelect } from '@/components/ui/themed-select'
 
 type SessionStatus = 'AGENDADO' | 'REALIZADO' | 'CANCELADO'
 type SessionType = 'PRESENTIAL' | 'HOME_CARE'
+type AttendanceType = 'CLINIC' | 'HOME_CARE' | 'HOSPITAL' | 'CORPORATE' | 'ONLINE'
+
+interface WorkplaceSummary {
+  id: string
+  name: string
+  defaultAttendanceType: AttendanceType
+}
 
 interface SessionFormData {
   date: string
   duration: string
   type: SessionType
   status: SessionStatus
+  workplaceId: string
+  attendanceType: AttendanceType
   subjective: string
   objective: string
   assessment: string
@@ -30,6 +39,8 @@ export interface SessionFormInitialValues {
   duration: number
   type: SessionType
   status: SessionStatus
+  workplaceId?: string | null
+  attendanceType?: AttendanceType | null
   subjective?: string | null
   objective?: string | null
   assessment?: string | null
@@ -57,6 +68,14 @@ interface EmailSummary {
 const sessionTypeOptions: Array<{ value: SessionType; label: string }> = [
   { value: 'PRESENTIAL', label: 'Presencial' },
   { value: 'HOME_CARE', label: 'Domiciliar' },
+]
+
+const attendanceTypeOptions: Array<{ value: AttendanceType; label: string }> = [
+  { value: 'CLINIC', label: 'Clínica' },
+  { value: 'HOME_CARE', label: 'Domiciliar' },
+  { value: 'HOSPITAL', label: 'Hospital' },
+  { value: 'CORPORATE', label: 'Corporativo' },
+  { value: 'ONLINE', label: 'Online' },
 ]
 
 const createStatusOptions: Array<{ value: SessionStatus; label: string }> = [
@@ -113,6 +132,8 @@ function buildInitialFormData(
       duration: String(initialValues.duration),
       type: initialValues.type,
       status: initialValues.status,
+      workplaceId: initialValues.workplaceId ?? '',
+      attendanceType: initialValues.attendanceType ?? 'CLINIC',
       subjective: initialValues.subjective ?? '',
       objective: initialValues.objective ?? '',
       assessment: initialValues.assessment ?? '',
@@ -126,6 +147,8 @@ function buildInitialFormData(
     duration: '50',
     type: patient.area === 'HOME_CARE' ? 'HOME_CARE' : 'PRESENTIAL',
     status: 'AGENDADO',
+    workplaceId: '',
+    attendanceType: patient.area === 'HOME_CARE' ? 'HOME_CARE' : 'CLINIC',
     subjective: '',
     objective: '',
     assessment: '',
@@ -174,6 +197,26 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
   const [sendReminder, setSendReminder] = useState(false)
   const [calendarConnected, setCalendarConnected] = useState(false)
   const [loadingCalendarSettings, setLoadingCalendarSettings] = useState(true)
+  const [workplaces, setWorkplaces] = useState<WorkplaceSummary[]>([])
+
+  useEffect(() => {
+    fetch('/api/workplaces')
+      .then((r) => r.json())
+      .then((data) => {
+        const list: WorkplaceSummary[] = data.workplaces ?? []
+        setWorkplaces(list)
+        if (!isEdit && list.length > 0 && !form.workplaceId) {
+          const first = list[0]
+          setForm((prev) => ({
+            ...prev,
+            workplaceId: first.id,
+            attendanceType: prev.attendanceType !== 'CLINIC' ? prev.attendanceType : first.defaultAttendanceType,
+          }))
+        }
+      })
+      .catch(() => undefined)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEdit])
 
   useEffect(() => {
     fetch('/api/settings/email')
@@ -234,6 +277,8 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
         duration: Number(form.duration),
         type: form.type,
         status: form.status,
+        workplaceId: form.workplaceId || undefined,
+        attendanceType: form.attendanceType || undefined,
         subjective: form.subjective,
         objective: form.objective,
         assessment: form.assessment,
@@ -351,6 +396,33 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
               onChange={(next) => set('status', next as SessionStatus)}
               options={statusOptions}
               ariaLabel="Status do atendimento"
+            />
+          </Field>
+
+          {workplaces.length > 0 ? (
+            <Field label="Local de trabalho" error={errors.workplaceId}>
+              <ThemedSelect
+                value={form.workplaceId}
+                onChange={(next) => {
+                  const selected = workplaces.find((w) => w.id === next)
+                  set('workplaceId', next)
+                  if (selected) set('attendanceType', selected.defaultAttendanceType)
+                }}
+                options={[
+                  { value: '', label: 'Sem local específico' },
+                  ...workplaces.map((w) => ({ value: w.id, label: w.name })),
+                ]}
+                ariaLabel="Local de trabalho"
+              />
+            </Field>
+          ) : null}
+
+          <Field label="Modalidade" error={errors.attendanceType}>
+            <ThemedSelect
+              value={form.attendanceType}
+              onChange={(next) => set('attendanceType', next as AttendanceType)}
+              options={attendanceTypeOptions}
+              ariaLabel="Modalidade de atendimento"
             />
           </Field>
         </div>

--- a/src/components/ui/datetime-picker.tsx
+++ b/src/components/ui/datetime-picker.tsx
@@ -118,12 +118,15 @@ export function DateTimePicker({
   const [viewYear, setViewYear] = useState(fallback.year)
   const [viewMonth, setViewMonth] = useState(fallback.month)
 
+  // Sync calendar view to the selected value when the picker opens
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (open && parsed) {
       setViewYear(parsed.year)
       setViewMonth(parsed.month)
     }
   }, [open, parsed])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   useEffect(() => {
     if (!open) return

--- a/src/components/workplaces/WorkplaceCard.tsx
+++ b/src/components/workplaces/WorkplaceCard.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Archive, Building2, Home, Globe, MapPin, Pencil, Stethoscope } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+type WorkplaceKind = 'OWN_CLINIC' | 'PARTNER_CLINIC' | 'PARTICULAR' | 'ONLINE'
+type AttendanceType = 'CLINIC' | 'HOME_CARE' | 'HOSPITAL' | 'CORPORATE' | 'ONLINE'
+
+const KIND_LABELS: Record<WorkplaceKind, string> = {
+  OWN_CLINIC: 'Própria clínica',
+  PARTNER_CLINIC: 'Clínica parceira',
+  PARTICULAR: 'Particular',
+  ONLINE: 'Online',
+}
+
+const ATTENDANCE_LABELS: Record<AttendanceType, string> = {
+  CLINIC: 'Clínica',
+  HOME_CARE: 'Domiciliar',
+  HOSPITAL: 'Hospital',
+  CORPORATE: 'Corporativo',
+  ONLINE: 'Online',
+}
+
+function KindIcon({ kind }: { kind: WorkplaceKind }) {
+  if (kind === 'ONLINE') return <Globe className="h-4 w-4" />
+  if (kind === 'PARTICULAR') return <Home className="h-4 w-4" />
+  return <Building2 className="h-4 w-4" />
+}
+
+interface WorkplaceCardProps {
+  workplace: {
+    id: string
+    name: string
+    kind: WorkplaceKind
+    defaultAttendanceType: AttendanceType
+    address?: string | null
+    notes?: string | null
+    isActive: boolean
+  }
+  onEdit: (id: string) => void
+}
+
+export function WorkplaceCard({ workplace, onEdit }: WorkplaceCardProps) {
+  const router = useRouter()
+  const [archiving, setArchiving] = useState(false)
+
+  async function handleArchive() {
+    if (!confirm(`Arquivar "${workplace.name}"? Ele não aparecerá em novos atendimentos.`)) return
+    setArchiving(true)
+    try {
+      await fetch(`/api/workplaces/${workplace.id}`, { method: 'DELETE' })
+      router.refresh()
+    } finally {
+      setArchiving(false)
+    }
+  }
+
+  return (
+    <article
+      className={cn(
+        'rounded-[20px] border border-border bg-card p-5 shadow-sm',
+        !workplace.isActive && 'opacity-60'
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary-soft text-primary">
+            <KindIcon kind={workplace.kind} />
+          </div>
+          <div className="min-w-0 space-y-1">
+            <p className="font-display text-[17px] font-bold leading-tight text-foreground">
+              {workplace.name}
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded-full bg-primary-soft px-2.5 py-0.5 font-body text-[11px] font-semibold text-primary-soft-fg">
+                {KIND_LABELS[workplace.kind]}
+              </span>
+              <span className="flex items-center gap-1 font-body text-[12px] text-muted-foreground">
+                <Stethoscope className="h-3.5 w-3.5" />
+                {ATTENDANCE_LABELS[workplace.defaultAttendanceType]}
+              </span>
+            </div>
+            {workplace.address ? (
+              <p className="flex items-center gap-1.5 font-body text-[12px] text-muted-foreground">
+                <MapPin className="h-3.5 w-3.5 shrink-0" />
+                {workplace.address}
+              </p>
+            ) : null}
+            {workplace.notes ? (
+              <p className="font-body text-[12px] italic text-muted-foreground">{workplace.notes}</p>
+            ) : null}
+          </div>
+        </div>
+
+        {workplace.isActive ? (
+          <div className="flex shrink-0 items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => onEdit(workplace.id)}
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors hover:border-primary/40 hover:bg-primary-soft hover:text-primary"
+              aria-label="Editar local"
+            >
+              <Pencil className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={handleArchive}
+              disabled={archiving}
+              className="flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors hover:border-danger/40 hover:bg-danger-soft hover:text-danger disabled:opacity-50"
+              aria-label="Arquivar local"
+            >
+              <Archive className="h-4 w-4" />
+            </button>
+          </div>
+        ) : (
+          <span className="shrink-0 rounded-full bg-muted px-2.5 py-0.5 font-body text-[11px] font-semibold text-muted-foreground">
+            Arquivado
+          </span>
+        )}
+      </div>
+    </article>
+  )
+}

--- a/src/components/workplaces/WorkplaceForm.tsx
+++ b/src/components/workplaces/WorkplaceForm.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import { ThemedSelect } from '@/components/ui/themed-select'
+
+type WorkplaceKind = 'OWN_CLINIC' | 'PARTNER_CLINIC' | 'PARTICULAR' | 'ONLINE'
+type AttendanceType = 'CLINIC' | 'HOME_CARE' | 'HOSPITAL' | 'CORPORATE' | 'ONLINE'
+
+interface WorkplaceFormData {
+  name: string
+  kind: WorkplaceKind
+  defaultAttendanceType: AttendanceType
+  address: string
+  notes: string
+}
+
+const kindOptions: Array<{ value: WorkplaceKind; label: string }> = [
+  { value: 'OWN_CLINIC', label: 'Própria clínica' },
+  { value: 'PARTNER_CLINIC', label: 'Clínica parceira' },
+  { value: 'PARTICULAR', label: 'Particular' },
+  { value: 'ONLINE', label: 'Online' },
+]
+
+const attendanceOptions: Array<{ value: AttendanceType; label: string }> = [
+  { value: 'CLINIC', label: 'Clínica' },
+  { value: 'HOME_CARE', label: 'Domiciliar' },
+  { value: 'HOSPITAL', label: 'Hospital' },
+  { value: 'CORPORATE', label: 'Corporativo' },
+  { value: 'ONLINE', label: 'Online' },
+]
+
+export interface WorkplaceFormInitialValues {
+  id: string
+  name: string
+  kind: WorkplaceKind
+  defaultAttendanceType: AttendanceType
+  address?: string | null
+  notes?: string | null
+}
+
+interface WorkplaceFormProps {
+  mode: 'create' | 'edit'
+  initialValues?: WorkplaceFormInitialValues
+  onSuccess: () => void
+  onCancel: () => void
+}
+
+const inputClass = cn(
+  'w-full rounded-xl border border-border bg-input px-3.5 py-2.5',
+  'font-body text-[14px] text-foreground placeholder:text-muted-foreground',
+  'focus:border-primary focus:outline-none focus:ring-2 focus:ring-ring',
+  'transition-colors duration-[180ms]'
+)
+
+function Field({
+  label,
+  error,
+  children,
+}: {
+  label: string
+  error?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="font-body text-[12px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+        {label}
+      </label>
+      {children}
+      {error ? <p className="font-body text-[12px] text-danger">{error}</p> : null}
+    </div>
+  )
+}
+
+export function WorkplaceForm({ mode, initialValues, onSuccess, onCancel }: WorkplaceFormProps) {
+  const [form, setForm] = useState<WorkplaceFormData>({
+    name: initialValues?.name ?? '',
+    kind: initialValues?.kind ?? 'OWN_CLINIC',
+    defaultAttendanceType: initialValues?.defaultAttendanceType ?? 'CLINIC',
+    address: initialValues?.address ?? '',
+    notes: initialValues?.notes ?? '',
+  })
+  const [errors, setErrors] = useState<Partial<Record<keyof WorkplaceFormData, string>>>({})
+  const [serverError, setServerError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  function set<K extends keyof WorkplaceFormData>(key: K, value: WorkplaceFormData[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }))
+    setErrors((prev) => ({ ...prev, [key]: undefined }))
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setServerError('')
+    setIsLoading(true)
+
+    try {
+      const url = mode === 'edit' ? `/api/workplaces/${initialValues!.id}` : '/api/workplaces'
+      const method = mode === 'edit' ? 'PUT' : 'POST'
+
+      const response = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          kind: form.kind,
+          defaultAttendanceType: form.defaultAttendanceType,
+          address: form.address || undefined,
+          notes: form.notes || undefined,
+        }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        if (data.errors) {
+          const fieldErrors: typeof errors = {}
+          for (const [key, value] of Object.entries(data.errors)) {
+            fieldErrors[key as keyof WorkplaceFormData] = (value as string[])[0]
+          }
+          setErrors(fieldErrors)
+        } else {
+          setServerError(data.message ?? 'Erro ao salvar local')
+        }
+        return
+      }
+
+      onSuccess()
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {serverError ? (
+        <div className="rounded-xl border border-danger/20 bg-danger-soft px-4 py-3 font-body text-[13px] text-danger">
+          {serverError}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="sm:col-span-2">
+          <Field label="Nome *" error={errors.name}>
+            <input
+              type="text"
+              className={inputClass}
+              value={form.name}
+              onChange={(e) => set('name', e.target.value)}
+              placeholder="Ex: Clínica Movimento, Atendimento Particular"
+              autoFocus
+            />
+          </Field>
+        </div>
+
+        <Field label="Tipo do local *" error={errors.kind}>
+          <ThemedSelect
+            value={form.kind}
+            onChange={(next) => set('kind', next as WorkplaceKind)}
+            options={kindOptions}
+            ariaLabel="Tipo do local"
+          />
+        </Field>
+
+        <Field label="Tipo de atendimento padrão *" error={errors.defaultAttendanceType}>
+          <ThemedSelect
+            value={form.defaultAttendanceType}
+            onChange={(next) => set('defaultAttendanceType', next as AttendanceType)}
+            options={attendanceOptions}
+            ariaLabel="Tipo de atendimento padrão"
+          />
+        </Field>
+
+        <div className="sm:col-span-2">
+          <Field label="Endereço" error={errors.address}>
+            <input
+              type="text"
+              className={inputClass}
+              value={form.address}
+              onChange={(e) => set('address', e.target.value)}
+              placeholder="Rua, número — opcional"
+            />
+          </Field>
+        </div>
+
+        <div className="sm:col-span-2">
+          <Field label="Observações" error={errors.notes}>
+            <textarea
+              className={cn(inputClass, 'min-h-[80px] resize-y')}
+              value={form.notes}
+              onChange={(e) => set('notes', e.target.value)}
+              placeholder="Informações adicionais sobre este local"
+            />
+          </Field>
+        </div>
+      </div>
+
+      <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="w-full rounded-xl px-5 py-2.5 font-body text-[13px] font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground sm:w-auto"
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full rounded-xl bg-primary px-6 py-2.5 font-body text-[13px] font-semibold text-primary-foreground shadow-glow transition-colors hover:bg-primary-hover disabled:opacity-50 sm:w-auto"
+        >
+          {isLoading ? 'Salvando...' : mode === 'edit' ? 'Salvar alterações' : 'Adicionar local'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/workplaces/WorkplacesManager.tsx
+++ b/src/components/workplaces/WorkplacesManager.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Plus } from 'lucide-react'
+import { WorkplaceCard } from './WorkplaceCard'
+import { WorkplaceForm, type WorkplaceFormInitialValues } from './WorkplaceForm'
+
+type WorkplaceKind = 'OWN_CLINIC' | 'PARTNER_CLINIC' | 'PARTICULAR' | 'ONLINE'
+type AttendanceType = 'CLINIC' | 'HOME_CARE' | 'HOSPITAL' | 'CORPORATE' | 'ONLINE'
+
+interface Workplace {
+  id: string
+  name: string
+  kind: WorkplaceKind
+  defaultAttendanceType: AttendanceType
+  address?: string | null
+  notes?: string | null
+  isActive: boolean
+}
+
+interface WorkplacesManagerProps {
+  initialWorkplaces: Workplace[]
+}
+
+export function WorkplacesManager({ initialWorkplaces }: WorkplacesManagerProps) {
+  const router = useRouter()
+  const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+
+  const editingWorkplace = editingId
+    ? initialWorkplaces.find((w) => w.id === editingId)
+    : undefined
+
+  function handleEdit(id: string) {
+    setEditingId(id)
+    setShowForm(false)
+  }
+
+  function handleSuccess() {
+    setShowForm(false)
+    setEditingId(null)
+    router.refresh()
+  }
+
+  function handleCancel() {
+    setShowForm(false)
+    setEditingId(null)
+  }
+
+  const editInitialValues: WorkplaceFormInitialValues | undefined = editingWorkplace
+    ? {
+        id: editingWorkplace.id,
+        name: editingWorkplace.name,
+        kind: editingWorkplace.kind,
+        defaultAttendanceType: editingWorkplace.defaultAttendanceType,
+        address: editingWorkplace.address,
+        notes: editingWorkplace.notes,
+      }
+    : undefined
+
+  return (
+    <div className="space-y-5">
+      {editingId && editInitialValues ? (
+        <section className="rounded-[18px] border border-border bg-card p-5 sm:p-6">
+          <h2 className="mb-5 font-display text-[18px] font-bold text-foreground">Editar local</h2>
+          <WorkplaceForm
+            mode="edit"
+            initialValues={editInitialValues}
+            onSuccess={handleSuccess}
+            onCancel={handleCancel}
+          />
+        </section>
+      ) : showForm ? (
+        <section className="rounded-[18px] border border-border bg-card p-5 sm:p-6">
+          <h2 className="mb-5 font-display text-[18px] font-bold text-foreground">
+            Adicionar local de trabalho
+          </h2>
+          <WorkplaceForm mode="create" onSuccess={handleSuccess} onCancel={handleCancel} />
+        </section>
+      ) : (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => setShowForm(true)}
+            className="flex items-center gap-2 rounded-xl bg-primary px-5 py-2.5 font-body text-[13px] font-semibold text-primary-foreground shadow-glow transition-colors hover:bg-primary-hover"
+          >
+            <Plus className="h-4 w-4" />
+            Adicionar local
+          </button>
+        </div>
+      )}
+
+      {initialWorkplaces.length === 0 && !showForm && !editingId ? (
+        <div className="rounded-[18px] border border-dashed border-border px-6 py-12 text-center">
+          <p className="font-body text-[14px] text-muted-foreground">
+            Nenhum local cadastrado ainda. Adicione seu primeiro local de trabalho.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {initialWorkplaces.map((workplace) => (
+            <WorkplaceCard key={workplace.id} workplace={workplace} onEdit={handleEdit} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/server/modules/sessions/application/create-session.ts
+++ b/src/server/modules/sessions/application/create-session.ts
@@ -1,6 +1,7 @@
-import type { SessionStatus, SessionType } from '@/generated/prisma/client'
+import type { AttendanceType, SessionStatus, SessionType } from '@/generated/prisma/client'
 import { PatientNotFoundError } from '@/server/modules/patients/application/get-patient'
 import { findPatientById } from '@/server/modules/patients/infra/patient.repository'
+import { findDefaultWorkplace } from '@/server/modules/workplaces/infra/workplace.repository'
 import type { CreateSessionDTO } from '../http/session.dto'
 import { createSession } from '../infra/session.repository'
 import { assertSessionSchedule, normalizeSessionSoapInput } from '../domain/session'
@@ -18,6 +19,23 @@ export async function createSessionUseCase(userId: string, dto: CreateSessionDTO
 
   assertSessionSchedule(date, status)
 
+  let workplaceId = dto.workplaceId ?? null
+  let attendanceType = (dto.attendanceType as AttendanceType | undefined) ?? null
+
+  if (!workplaceId) {
+    const defaultWorkplace = await findDefaultWorkplace(userId)
+    if (defaultWorkplace) {
+      workplaceId = defaultWorkplace.id
+      if (!attendanceType) {
+        attendanceType = defaultWorkplace.defaultAttendanceType
+      }
+    }
+  }
+
+  if (!attendanceType) {
+    attendanceType = dto.type === 'HOME_CARE' ? 'HOME_CARE' : 'CLINIC'
+  }
+
   const createdSession = await createSession({
     userId,
     patientId: dto.patientId,
@@ -25,6 +43,8 @@ export async function createSessionUseCase(userId: string, dto: CreateSessionDTO
     duration: dto.duration,
     type: dto.type as SessionType,
     status,
+    workplaceId,
+    attendanceType,
     ...normalizeSessionSoapInput({
       subjective: dto.subjective,
       objective: dto.objective,

--- a/src/server/modules/sessions/application/update-session.ts
+++ b/src/server/modules/sessions/application/update-session.ts
@@ -1,4 +1,4 @@
-import type { SessionStatus, SessionType } from '@/generated/prisma/client'
+import type { AttendanceType, SessionStatus, SessionType } from '@/generated/prisma/client'
 import type { UpdateSessionDTO } from '../http/session.dto'
 import { normalizePartialSessionSoapInput, assertSessionSchedule } from '../domain/session'
 import { findSessionById, updateSession } from '../infra/session.repository'
@@ -22,6 +22,8 @@ export async function updateSessionUseCase(id: string, userId: string, dto: Upda
     duration: dto.duration,
     type: dto.type as SessionType | undefined,
     status: dto.status as SessionStatus | undefined,
+    workplaceId: dto.workplaceId,
+    attendanceType: dto.attendanceType as AttendanceType | undefined,
     ...normalizePartialSessionSoapInput({
       subjective: dto.subjective,
       objective: dto.objective,

--- a/src/server/modules/sessions/http/session.dto.ts
+++ b/src/server/modules/sessions/http/session.dto.ts
@@ -24,6 +24,10 @@ export const createSessionDTO = z.object({
     .max(240, 'Duração máxima de 240 minutos'),
   type: z.enum(['PRESENTIAL', 'HOME_CARE']).default('PRESENTIAL'),
   status: z.enum(['AGENDADO', 'REALIZADO', 'CANCELADO']).default('AGENDADO'),
+  workplaceId: z.string().trim().optional(),
+  attendanceType: z
+    .enum(['CLINIC', 'HOME_CARE', 'HOSPITAL', 'CORPORATE', 'ONLINE'])
+    .optional(),
   subjective: optionalText,
   objective: optionalText,
   assessment: optionalText,
@@ -41,6 +45,10 @@ export const updateSessionDTO = z.object({
     .optional(),
   type: z.enum(['PRESENTIAL', 'HOME_CARE']).optional(),
   status: z.enum(['AGENDADO', 'REALIZADO', 'CANCELADO']).optional(),
+  workplaceId: z.string().trim().optional(),
+  attendanceType: z
+    .enum(['CLINIC', 'HOME_CARE', 'HOSPITAL', 'CORPORATE', 'ONLINE'])
+    .optional(),
   subjective: optionalText,
   objective: optionalText,
   assessment: optionalText,

--- a/src/server/modules/sessions/infra/session.repository.ts
+++ b/src/server/modules/sessions/infra/session.repository.ts
@@ -108,7 +108,7 @@ export async function listSessions(userId: string, filters: ListSessionFilters =
   const page = filters.page ?? 1
   const limit = filters.limit ?? 20
 
-  const [sessions, total] = await prisma.$transaction([
+  const [sessions, total] = await Promise.all([
     prisma.session.findMany({
       where,
       include: sessionInclude,

--- a/src/server/modules/sessions/infra/session.repository.ts
+++ b/src/server/modules/sessions/infra/session.repository.ts
@@ -1,5 +1,11 @@
 import { prisma } from '@/lib/prisma'
-import type { Prisma, SessionStatus, SessionType, TherapyArea } from '@/generated/prisma/client'
+import type {
+  AttendanceType,
+  Prisma,
+  SessionStatus,
+  SessionType,
+  TherapyArea,
+} from '@/generated/prisma/client'
 
 const sessionInclude = {
   patient: {
@@ -14,6 +20,9 @@ const sessionInclude = {
       city: true,
       email: true,
     },
+  },
+  workplace: {
+    select: { id: true, name: true },
   },
   calendarEventLinks: {
     where: { provider: 'GOOGLE' },
@@ -38,6 +47,8 @@ export interface SessionCreateInput {
   duration: number
   type: SessionType
   status: SessionStatus
+  workplaceId?: string | null
+  attendanceType?: AttendanceType | null
   subjective?: string | null
   objective?: string | null
   assessment?: string | null
@@ -49,6 +60,8 @@ export interface SessionUpdateInput {
   duration?: number
   type?: SessionType
   status?: SessionStatus
+  workplaceId?: string | null
+  attendanceType?: AttendanceType | null
   subjective?: string | null
   objective?: string | null
   assessment?: string | null

--- a/src/server/modules/workplaces/application/archive-workplace.ts
+++ b/src/server/modules/workplaces/application/archive-workplace.ts
@@ -1,0 +1,8 @@
+import { WorkplaceNotFoundError } from '../domain/workplace'
+import { archiveWorkplace, findWorkplaceById } from '../infra/workplace.repository'
+
+export async function archiveWorkplaceUseCase(id: string, userId: string) {
+  const existing = await findWorkplaceById(id, userId)
+  if (!existing) throw new WorkplaceNotFoundError()
+  return archiveWorkplace(id)
+}

--- a/src/server/modules/workplaces/application/create-workplace.test.ts
+++ b/src/server/modules/workplaces/application/create-workplace.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createWorkplaceUseCase } from './create-workplace'
+import { createWorkplace } from '../infra/workplace.repository'
+
+vi.mock('../infra/workplace.repository')
+const mockCreateWorkplace = vi.mocked(createWorkplace)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createWorkplaceUseCase', () => {
+  it('cria workplace com dados válidos', async () => {
+    mockCreateWorkplace.mockResolvedValue({ id: 'wp-1', name: 'Clínica Mova' } as never)
+
+    await createWorkplaceUseCase('user-1', {
+      name: 'Clínica Mova',
+      kind: 'OWN_CLINIC',
+      defaultAttendanceType: 'CLINIC',
+    })
+
+    expect(mockCreateWorkplace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        name: 'Clínica Mova',
+        kind: 'OWN_CLINIC',
+        defaultAttendanceType: 'CLINIC',
+      })
+    )
+  })
+
+  it('propaga campos opcionais', async () => {
+    mockCreateWorkplace.mockResolvedValue({ id: 'wp-2' } as never)
+
+    await createWorkplaceUseCase('user-1', {
+      name: 'Studio',
+      kind: 'PARTICULAR',
+      defaultAttendanceType: 'HOME_CARE',
+      address: 'Rua A, 10',
+      defaultSessionPrice: 200,
+      defaultCommissionPct: 10,
+      notes: 'Atendimento VIP',
+    })
+
+    expect(mockCreateWorkplace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: 'Rua A, 10',
+        defaultSessionPrice: 200,
+        defaultCommissionPct: 10,
+        notes: 'Atendimento VIP',
+      })
+    )
+  })
+})

--- a/src/server/modules/workplaces/application/create-workplace.ts
+++ b/src/server/modules/workplaces/application/create-workplace.ts
@@ -1,0 +1,16 @@
+import type { AttendanceType, WorkplaceKind } from '@/generated/prisma/client'
+import type { CreateWorkplaceDTO } from '../http/workplace.dto'
+import { createWorkplace } from '../infra/workplace.repository'
+
+export async function createWorkplaceUseCase(userId: string, dto: CreateWorkplaceDTO) {
+  return createWorkplace({
+    userId,
+    name: dto.name,
+    kind: dto.kind as WorkplaceKind,
+    defaultAttendanceType: dto.defaultAttendanceType as AttendanceType,
+    address: dto.address,
+    defaultSessionPrice: dto.defaultSessionPrice,
+    defaultCommissionPct: dto.defaultCommissionPct,
+    notes: dto.notes,
+  })
+}

--- a/src/server/modules/workplaces/application/get-workplace.ts
+++ b/src/server/modules/workplaces/application/get-workplace.ts
@@ -1,0 +1,10 @@
+import { WorkplaceNotFoundError } from '../domain/workplace'
+import { findWorkplaceById } from '../infra/workplace.repository'
+
+export { WorkplaceNotFoundError }
+
+export async function getWorkplaceUseCase(id: string, userId: string) {
+  const workplace = await findWorkplaceById(id, userId)
+  if (!workplace) throw new WorkplaceNotFoundError()
+  return workplace
+}

--- a/src/server/modules/workplaces/application/list-workplaces.test.ts
+++ b/src/server/modules/workplaces/application/list-workplaces.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { listWorkplacesUseCase } from './list-workplaces'
+import { listWorkplaces } from '../infra/workplace.repository'
+
+vi.mock('../infra/workplace.repository')
+const mockListWorkplaces = vi.mocked(listWorkplaces)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('listWorkplacesUseCase', () => {
+  it('lista apenas workplaces ativos por default', async () => {
+    mockListWorkplaces.mockResolvedValue([])
+
+    await listWorkplacesUseCase('user-1', { includeArchived: false })
+
+    expect(mockListWorkplaces).toHaveBeenCalledWith('user-1', false)
+  })
+
+  it('passa includeArchived=true ao repositório', async () => {
+    mockListWorkplaces.mockResolvedValue([])
+
+    await listWorkplacesUseCase('user-1', { includeArchived: true })
+
+    expect(mockListWorkplaces).toHaveBeenCalledWith('user-1', true)
+  })
+
+  it('retorna objeto { workplaces }', async () => {
+    const fakeList = [{ id: 'wp-1' }]
+    mockListWorkplaces.mockResolvedValue(fakeList as never)
+
+    const result = await listWorkplacesUseCase('user-1', { includeArchived: false })
+
+    expect(result).toEqual({ workplaces: fakeList })
+  })
+})

--- a/src/server/modules/workplaces/application/list-workplaces.ts
+++ b/src/server/modules/workplaces/application/list-workplaces.ts
@@ -1,0 +1,7 @@
+import type { ListWorkplacesDTO } from '../http/workplace.dto'
+import { listWorkplaces } from '../infra/workplace.repository'
+
+export async function listWorkplacesUseCase(userId: string, dto: ListWorkplacesDTO) {
+  const workplaces = await listWorkplaces(userId, dto.includeArchived)
+  return { workplaces }
+}

--- a/src/server/modules/workplaces/application/update-workplace.ts
+++ b/src/server/modules/workplaces/application/update-workplace.ts
@@ -1,0 +1,19 @@
+import type { AttendanceType, WorkplaceKind } from '@/generated/prisma/client'
+import { WorkplaceNotFoundError } from '../domain/workplace'
+import type { UpdateWorkplaceDTO } from '../http/workplace.dto'
+import { findWorkplaceById, updateWorkplace } from '../infra/workplace.repository'
+
+export async function updateWorkplaceUseCase(id: string, userId: string, dto: UpdateWorkplaceDTO) {
+  const existing = await findWorkplaceById(id, userId)
+  if (!existing) throw new WorkplaceNotFoundError()
+
+  return updateWorkplace(id, {
+    name: dto.name,
+    kind: dto.kind as WorkplaceKind | undefined,
+    defaultAttendanceType: dto.defaultAttendanceType as AttendanceType | undefined,
+    address: dto.address,
+    defaultSessionPrice: dto.defaultSessionPrice,
+    defaultCommissionPct: dto.defaultCommissionPct,
+    notes: dto.notes,
+  })
+}

--- a/src/server/modules/workplaces/domain/workplace.ts
+++ b/src/server/modules/workplaces/domain/workplace.ts
@@ -1,0 +1,6 @@
+export class WorkplaceNotFoundError extends Error {
+  constructor(message = 'Local de trabalho não encontrado') {
+    super(message)
+    this.name = 'WorkplaceNotFoundError'
+  }
+}

--- a/src/server/modules/workplaces/http/workplace.dto.ts
+++ b/src/server/modules/workplaces/http/workplace.dto.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+
+const workplaceKind = z.enum(['OWN_CLINIC', 'PARTNER_CLINIC', 'PARTICULAR', 'ONLINE'])
+const attendanceTypeEnum = z.enum(['CLINIC', 'HOME_CARE', 'HOSPITAL', 'CORPORATE', 'ONLINE'])
+const optionalText = z.string().trim().optional()
+
+export const createWorkplaceDTO = z.object({
+  name: z.string().trim().min(1, 'Nome é obrigatório').max(120, 'Nome muito longo'),
+  kind: workplaceKind,
+  defaultAttendanceType: attendanceTypeEnum,
+  address: optionalText,
+  defaultSessionPrice: z.coerce.number().nonnegative().optional(),
+  defaultCommissionPct: z.coerce.number().min(0).max(100).optional(),
+  notes: optionalText,
+})
+
+export const updateWorkplaceDTO = z.object({
+  name: z.string().trim().min(1).max(120).optional(),
+  kind: workplaceKind.optional(),
+  defaultAttendanceType: attendanceTypeEnum.optional(),
+  address: optionalText,
+  defaultSessionPrice: z.coerce.number().nonnegative().optional(),
+  defaultCommissionPct: z.coerce.number().min(0).max(100).optional(),
+  notes: optionalText,
+})
+
+export const listWorkplacesDTO = z.object({
+  includeArchived: z
+    .string()
+    .optional()
+    .transform((v) => v === 'true'),
+})
+
+export type CreateWorkplaceDTO = z.infer<typeof createWorkplaceDTO>
+export type UpdateWorkplaceDTO = z.infer<typeof updateWorkplaceDTO>
+export type ListWorkplacesDTO = z.infer<typeof listWorkplacesDTO>

--- a/src/server/modules/workplaces/infra/workplace.repository.ts
+++ b/src/server/modules/workplaces/infra/workplace.repository.ts
@@ -1,0 +1,57 @@
+import { prisma } from '@/lib/prisma'
+import type { AttendanceType, Prisma, WorkplaceKind } from '@/generated/prisma/client'
+
+export interface WorkplaceCreateInput {
+  userId: string
+  name: string
+  kind: WorkplaceKind
+  defaultAttendanceType: AttendanceType
+  address?: string
+  defaultSessionPrice?: number
+  defaultCommissionPct?: number
+  notes?: string
+}
+
+export interface WorkplaceUpdateInput {
+  name?: string
+  kind?: WorkplaceKind
+  defaultAttendanceType?: AttendanceType
+  address?: string | null
+  defaultSessionPrice?: number | null
+  defaultCommissionPct?: number | null
+  notes?: string | null
+}
+
+export async function createWorkplace(data: WorkplaceCreateInput) {
+  return prisma.workplace.create({ data })
+}
+
+export async function listWorkplaces(userId: string, includeArchived = false) {
+  const where: Prisma.WorkplaceWhereInput = {
+    userId,
+    ...(includeArchived ? {} : { isActive: true }),
+  }
+  return prisma.workplace.findMany({
+    where,
+    orderBy: [{ isActive: 'desc' }, { createdAt: 'asc' }],
+  })
+}
+
+export async function findWorkplaceById(id: string, userId: string) {
+  return prisma.workplace.findFirst({ where: { id, userId } })
+}
+
+export async function updateWorkplace(id: string, data: WorkplaceUpdateInput) {
+  return prisma.workplace.update({ where: { id }, data })
+}
+
+export async function archiveWorkplace(id: string) {
+  return prisma.workplace.update({ where: { id }, data: { isActive: false } })
+}
+
+export async function findDefaultWorkplace(userId: string) {
+  return prisma.workplace.findFirst({
+    where: { userId, isActive: true },
+    orderBy: { createdAt: 'asc' },
+  })
+}


### PR DESCRIPTION
Closes #5

## Resumo

Introduz o conceito de **Workplace** (Local de Trabalho) para fisioterapeutas que atendem em múltiplos locais — própria clínica, clínica parceira, particular e online. Toda sessão agora pode referenciar um local específico e uma modalidade de atendimento (`AttendanceType`), preparando o terreno para a Phase 15 (Plano de Tratamento).

## O que foi implementado

### Backend
- Enums `WorkplaceKind` e `AttendanceType` no schema Prisma
- Modelo `Workplace` com `kind`, `defaultAttendanceType`, endereço, preço padrão e comissão
- `Session` ganha `workplaceId` (FK nullable) e `attendanceType` (nullable)
- Migration `phase14_workplaces` com **backfill SQL**: 1 workplace default (`"Meu consultório"`) por usuário existente + sessões vinculadas com `attendanceType` derivado de `Session.type`
- Módulo `src/server/modules/workplaces/` completo: `domain`, `http` (DTOs Zod), `infra` (repository), `application` (5 use cases) + testes unitários
- `createSessionUseCase` busca workplace default quando `workplaceId` não fornecido
- Multi-tenant preservado em todas as queries

### API
- `POST /api/workplaces` — criar local
- `GET /api/workplaces?includeArchived=false` — listar
- `GET /api/workplaces/:id` — detalhe
- `PUT /api/workplaces/:id` — editar
- `DELETE /api/workplaces/:id` — arquivar (soft delete)
- `POST /api/sessions` e `PUT /api/sessions/:id` atualizados para aceitar `workplaceId` e `attendanceType`

### Frontend
- Página `/configuracoes/locais` com lista e formulário inline (criar/editar)
- Componentes `WorkplaceCard`, `WorkplaceForm`, `WorkplacesManager`
- `SessionForm`: seletor de local (preenche `attendanceType` com o default do workplace) + seletor de modalidade
- `SessionCard`: exibe nome do local em texto secundário
- Link **"Locais"** na sidebar (ícone `MapPin`)

### Seed & Docs
- Seed demo com "Clínica Movimento" (OWN_CLINIC) e "Atendimento Particular" (PARTICULAR)
- `CONTEXT.md`, `CHANGELOG.md`, `README.md` e task file atualizados

## Compatibilidade

`Session.type` e `Patient.area` **mantidos intactos** — serão removidos na Phase 15 junto com a criação dos `TreatmentPlan`s.

## Checklist

- [x] Migration aplicada no Neon com backfill
- [x] CRUD de workplace funcionando
- [x] `SessionForm` seleciona workplace e modalidade
- [x] `SessionCard` mostra nome do local
- [x] Multi-tenant mantido em todas as queries
- [x] Seed atualizado
- [x] `npm run lint` — sem erros
- [x] `npm run build` — sem erros
- [x] Testes unitários do módulo `workplaces`

Refs: `.docs/tasks/phase-14-workplaces.md` · `ADR-005`

🤖 Generated with [Claude Code](https://claude.com/claude-code)