### PR TITLE
[codex] Phase 15 — Plano de Tratamento

### DIFF
--- a/.docs/CHANGELOG.md
+++ b/.docs/CHANGELOG.md
@@ -9,6 +9,27 @@ e o projeto segue [Conventional Commits](https://www.conventionalcommits.org/) e
 
 ### Added
 
+- **Phase 15 — Plano de Tratamento**
+  - Modelo `TreatmentPlan` com `area`, `specialties`, `attendanceType`, `workplaceId`,
+    `pricingModel`, status e campos preparatórios de cobrança por sessão/pacote
+  - Enums `Specialty`, `PricingModel` e `PlanStatus`; enum `TherapyArea` expandido para
+    áreas clínicas atuais
+  - Migrations `phase15a_treatment_plans` e `phase15b_drop_legacy_fields` com backfill
+    de planos legados, vínculo de sessões existentes e remoção de `Patient.area`,
+    `Session.type` e `SessionType`
+  - Módulo `treatment-plans` com use cases, repository, DTOs Zod e testes unitários
+  - Endpoints REST:
+    `GET/POST /api/patients/:id/treatment-plans`,
+    `GET/PUT/DELETE /api/treatment-plans/:id`,
+    `POST /api/treatment-plans/:id/pause|resume|complete`
+  - Ficha do paciente com seção "Planos de tratamento", cards com contagem de sessões e
+    ações de editar, pausar, retomar, concluir e cancelar
+  - Páginas `/pacientes/:id/planos/novo` e `/pacientes/:id/planos/:planId/editar`
+  - `SessionForm` com seletor de plano ativo ou atendimento avulso, herdando local e
+    modalidade do plano quando selecionado
+  - Seed demo com paciente multi-modalidade, paciente de estética domiciliar e paciente
+    com sessões avulsas
+
 - **Phase 14 — Locais de Trabalho**
   - Enum `WorkplaceKind` (`OWN_CLINIC`, `PARTNER_CLINIC`, `PARTICULAR`, `ONLINE`)
   - Enum `AttendanceType` (`CLINIC`, `HOME_CARE`, `HOSPITAL`, `CORPORATE`, `ONLINE`)
@@ -44,14 +65,14 @@ e o projeto segue [Conventional Commits](https://www.conventionalcommits.org/) e
 
 ### Fixed
 
-  - Sidebar mobile: `useEffect` corrigido com `useRef` de pathname — o menu não fecha mais
-    imediatamente ao ser aberto; fecha apenas após navegação bem-sucedida
-  - Selects nativos substituídos por `ThemedSelect` em: `PatientFilters`, `DocumentFilters`,
-    `SessionForm` (Tipo, Status), `PatientForm` (Área, Classificação, Prioridade),
-    `NovoDocumentoModal` (Paciente, Tipo), `GoogleCalendarSettingsCard` (Agenda padrão)
-  - Input `datetime-local` e `date` substituídos por `DateTimePicker` em `SessionForm` e
-    `PatientForm`
-  - Emoji 👋 removido da saudação do dashboard
+- Sidebar mobile: `useEffect` corrigido com `useRef` de pathname — o menu não fecha mais
+  imediatamente ao ser aberto; fecha apenas após navegação bem-sucedida
+- Selects nativos substituídos por `ThemedSelect` em: `PatientFilters`, `DocumentFilters`,
+  `SessionForm` (Tipo, Status), `PatientForm` (Área, Classificação, Prioridade),
+  `NovoDocumentoModal` (Paciente, Tipo), `GoogleCalendarSettingsCard` (Agenda padrão)
+- Input `datetime-local` e `date` substituídos por `DateTimePicker` em `SessionForm` e
+  `PatientForm`
+- Emoji 👋 removido da saudação do dashboard
 
 - **Phase 10 — Edição SOAP e Agenda em Calendário**
   - `SessionForm` refatorado para suportar `mode="create" | "edit"` com `initialValues`,
@@ -175,6 +196,10 @@ e o projeto segue [Conventional Commits](https://www.conventionalcommits.org/) e
 
 ### Changed
 
+- Pacientes não têm mais área terapêutica própria; filtros e badges usam planos ativos.
+- Sessões usam `attendanceType` para modalidade e `treatmentPlanId` opcional para vínculo
+  clínico; e-mails, Google Calendar, agenda, dashboard e documentos foram atualizados para
+  esse modelo.
 - Phase 3 passou a criar e editar prontuário base junto com o cadastro do paciente
 - Datas de nascimento agora usam helpers UTC-safe para evitar drift de fuso
 - E-mail do paciente passou a ser validado como único por fisioterapeuta entre registros ativos

--- a/.docs/CONTEXT.md
+++ b/.docs/CONTEXT.md
@@ -4,6 +4,18 @@
 
 ## Fase Atual
 
+**Phase 15 — Plano de Tratamento concluída**
+Modelo `TreatmentPlan` criado com `TherapyArea` expandido, enums `Specialty`,
+`PricingModel` e `PlanStatus`, vínculo opcional de `Session.treatmentPlanId` e backfill
+SQL em duas migrations (`phase15a_treatment_plans` e `phase15b_drop_legacy_fields`).
+`Patient.area`, `Session.type` e `SessionType` foram removidos; `Session.workplaceId` e
+`Session.attendanceType` agora são obrigatórios. Módulo `treatment-plans` completo com
+CRUD/status REST, use cases e testes. Ficha do paciente ganhou seção "Planos de
+tratamento", páginas de novo/editar plano, `SessionForm` ganhou seletor de plano/avulso,
+agenda/e-mails/Google Calendar/documentos/dashboard passaram a usar `attendanceType` e
+área do plano. Seed demo mostra paciente com dois planos, paciente com estética domiciliar
+e paciente com sessões avulsas.
+
 **Phase 14 — Locais de Trabalho concluída**
 Enum `WorkplaceKind` (`OWN_CLINIC`, `PARTNER_CLINIC`, `PARTICULAR`, `ONLINE`) e enum
 `AttendanceType` (`CLINIC`, `HOME_CARE`, `HOSPITAL`, `CORPORATE`, `ONLINE`) adicionados.
@@ -54,16 +66,16 @@ Campos de endereço e prioridade no modelo `Patient`, seção de logística na f
 
 ## Próximo Passo Planejado
 
-**Phase 15 — Plano de Tratamento** — [task file](tasks/phase-15-treatment-plans.md)
-Modelo `TreatmentPlan` (1 paciente → N planos), expansão de `TherapyArea`, novo enum
-`Specialty`. Backfill cria plano legado por paciente. Remove `Patient.area` e
-`Session.type` (campos legados que coexistiram com os novos desde a Phase 14).
+**Phase 16 — Pagamentos** — [task file](tasks/phase-16-payments.md)
+Introduzir o financeiro real (`Payment`), snapshot `expectedFee` por sessão, cobranças
+avulsas e pacotes vinculados a `TreatmentPlan`.
 
 Sequência restante do ciclo "Multi-modalidade + Financeiro":
-- **Phase 16** — [Pagamentos](tasks/phase-16-payments.md)
+
 - **Phase 17** — [Dashboard financeiro](tasks/phase-17-finance-dashboard.md)
 
 Pendências operacionais:
+
 - Validar integrações em ambiente real (Phase 11/12) e preparar deploy na Vercel
 - Configurar `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALENDAR_REDIRECT_URI`
   e `INTEGRATION_ENCRYPTION_KEY` (esta última gerada com `openssl rand -base64 32`)
@@ -85,7 +97,6 @@ Pendências operacionais:
 
 ### Tasks planejadas
 
-- `.docs/tasks/phase-15-treatment-plans.md` — Plano de tratamento e multi-modalidade
 - `.docs/tasks/phase-16-payments.md` — Pagamentos e cobrança (avulso e pacote)
 - `.docs/tasks/phase-17-finance-dashboard.md` — Dashboard financeiro (recebido vs previsto)
 - `.docs/decisions/ADR-005-multi-modalidade-financeiro.md` — Decisão proposta para
@@ -94,6 +105,7 @@ Pendências operacionais:
 ### Tasks já concluídas (referência)
 
 - `.docs/tasks/phase-14-workplaces.md` — Locais de trabalho (`Workplace`, `AttendanceType`, CRUD + UI)
+- `.docs/tasks/phase-15-treatment-plans.md` — Plano de tratamento e multi-modalidade
 - `.docs/tasks/phase-9-ux-polish.md` — Polimentos visuais e de microinteração
 - `.docs/tasks/phase-10-clinical-agenda-flow.md` — Edição SOAP e visualização mensal da agenda
 - `.docs/tasks/phase-11-email-notifications.md` — Gmail App Password e envios
@@ -135,6 +147,16 @@ Pendências operacionais:
   - Componentes `SessionCard`, `StatusBadge` e `SessionForm`
   - Seed demo com histórico, agendamentos e atendimento domiciliar
   - Testes unitários cobrindo create/list/update do módulo
+- **Planos de Tratamento (Phase 15)**:
+  - Modelo `TreatmentPlan` com área, especialidades, modalidade, local, status e modelo
+    de cobrança preparatório para a Phase 16
+  - `POST/GET /api/patients/:id/treatment-plans`, `GET/PUT/DELETE /api/treatment-plans/:id`
+    e ações `pause`, `resume`, `complete`
+  - Ficha do paciente com cards de planos e ações de editar/pausar/concluir/cancelar
+  - Formulário de plano em `/pacientes/:id/planos/novo` e `/pacientes/:id/planos/:planId/editar`
+  - `SessionForm` com seletor de plano ativo ou atendimento avulso
+  - Filtros de pacientes/sessões por área usando planos ativos/vínculo de plano
+  - Seed demo com multi-modalidade e sessões avulsas
 - **Logística Domiciliar (Phase 8)**:
   - Enum `HomeCarePriority` + campos `address`, `neighborhood`, `city`, `homeCareNotes`, `homeCarePriority` no modelo `Patient` (migration `phase8_homecare_logistics`)
   - `PUT /api/patients/:id` aceita os novos campos via DTO Zod atualizado
@@ -185,9 +207,12 @@ Pendências operacionais:
 ## Modelos de Banco
 
 - `User` — id, email, name, password, createdAt, updatedAt
-- `Patient` — cadastro clínico base, classificação, área terapêutica, observações, endereço (address, neighborhood, city), homeCareNotes, homeCarePriority, `isActive`
+- `Patient` — cadastro clínico base, classificação, observações, endereço (address, neighborhood, city), homeCareNotes, homeCarePriority, `isActive`
 - `ClinicalRecord` — prontuário inicial vinculado 1:1 ao paciente
-- `Session` — atendimento clínico com data, duração, tipo, status e campos SOAP
+- `TreatmentPlan` — plano/modalidade clínica do paciente com área, especialidades,
+  local, modalidade, status e modelo de cobrança
+- `Session` — atendimento clínico com data, duração, status, plano opcional, local,
+  modalidade e campos SOAP
 - `Document` — metadados do documento gerado (tipo, título, período, patientId, userId), `isActive`
 - `CalendarConnection` — conexão Google Calendar por usuário, com tokens criptografados e agenda padrão
 - `CalendarEventLink` — vínculo entre uma sessão e um evento externo Google Calendar
@@ -205,6 +230,7 @@ Módulo `sessions` segue o mesmo padrão em `src/server/modules/sessions/`
 Módulo `documents` segue o mesmo padrão em `src/server/modules/documents/`
 Módulo `calendar` segue o mesmo padrão em `src/server/modules/calendar/`
 Módulo `workplaces` segue o mesmo padrão em `src/server/modules/workplaces/`
+Módulo `treatment-plans` segue o mesmo padrão em `src/server/modules/treatment-plans/`
 
 ## Pendências Conhecidas
 

--- a/.docs/tasks/phase-15-treatment-plans.md
+++ b/.docs/tasks/phase-15-treatment-plans.md
@@ -4,7 +4,7 @@
 
 - [ ] Todo
 - [ ] In Progress
-- [ ] Done
+- [x] Done
 
 ## Contexto
 
@@ -30,22 +30,22 @@ vinculadas a um plano legado. Remover `Patient.area` e `Session.type` do schema.
 
 ### Backend — Migration
 
-- [ ] Expandir enum `TherapyArea` com `ORTOPEDICA`, `NEUROLOGICA`, `CARDIORESPIRATORIA`,
-  `ESTETICA`, `ESPORTIVA`, `PELVICA`, `PEDIATRICA`, `GERIATRICA`, `PREVENTIVA`, `OUTRA`
-- [ ] Criar enum `Specialty` com `PILATES`, `RPG`, `ACUPUNTURA`, `LIBERACAO_MIOFASCIAL`,
-  `VENTOSATERAPIA`, `DRY_NEEDLING`, `TERAPIA_MANUAL`, `OUTRA`
-- [ ] Criar enum `PricingModel` com `PER_SESSION`, `PACKAGE`
-- [ ] Criar enum `PlanStatus` com `ACTIVE`, `COMPLETED`, `CANCELED`, `PAUSED`
-- [ ] Criar modelo `TreatmentPlan`
-- [ ] Adicionar `treatmentPlanId: String?` em `Session`
-- [ ] Adicionar relação reversa `treatmentPlans` em `User` e `Patient`
-- [ ] Adicionar relação reversa `sessions` em `TreatmentPlan`
+- [x] Expandir enum `TherapyArea` com `ORTOPEDICA`, `NEUROLOGICA`, `CARDIORESPIRATORIA`,
+      `ESTETICA`, `ESPORTIVA`, `PELVICA`, `PEDIATRICA`, `GERIATRICA`, `PREVENTIVA`, `OUTRA`
+- [x] Criar enum `Specialty` com `PILATES`, `RPG`, `ACUPUNTURA`, `LIBERACAO_MIOFASCIAL`,
+      `VENTOSATERAPIA`, `DRY_NEEDLING`, `TERAPIA_MANUAL`, `OUTRA`
+- [x] Criar enum `PricingModel` com `PER_SESSION`, `PACKAGE`
+- [x] Criar enum `PlanStatus` com `ACTIVE`, `COMPLETED`, `CANCELED`, `PAUSED`
+- [x] Criar modelo `TreatmentPlan`
+- [x] Adicionar `treatmentPlanId: String?` em `Session`
+- [x] Adicionar relação reversa `treatmentPlans` em `User` e `Patient`
+- [x] Adicionar relação reversa `sessions` em `TreatmentPlan`
 
 ### Backend — Backfill
 
 Em script idempotente executado depois da migration:
 
-- [ ] Para cada `Patient` ativo, criar 1 `TreatmentPlan` legado:
+- [x] Para cada `Patient` ativo, criar 1 `TreatmentPlan` legado:
   - `area` derivado do `Patient.area` antigo:
     - `MOTOR` → `ORTOPEDICA`
     - `AESTHETIC` → `ESTETICA`
@@ -57,82 +57,82 @@ Em script idempotente executado depois da migration:
   - `pricingModel = PER_SESSION`
   - `status = ACTIVE`
   - `notes` carrega marca "Plano legado migrado de v14"
-- [ ] Vincular todas as `Session` existentes do paciente ao plano legado
-- [ ] Validar que toda sessão tem `treatmentPlanId` antes de prosseguir
+- [x] Vincular todas as `Session` existentes do paciente ao plano legado
+- [x] Validar que toda sessão tem `treatmentPlanId` antes de prosseguir
 
 ### Backend — Migration de fechamento
 
-- [ ] Remover `Patient.area`
-- [ ] Remover `Session.type` e enum `SessionType`
-- [ ] Tornar `Session.workplaceId` `NOT NULL`
-- [ ] Tornar `Session.attendanceType` `NOT NULL`
-- [ ] Descontinuar valores antigos do enum `TherapyArea` (`MOTOR`, `AESTHETIC`, `PILATES`,
+- [x] Remover `Patient.area`
+- [x] Remover `Session.type` e enum `SessionType`
+- [x] Tornar `Session.workplaceId` `NOT NULL`
+- [x] Tornar `Session.attendanceType` `NOT NULL`
+- [x] Descontinuar valores antigos do enum `TherapyArea` (`MOTOR`, `AESTHETIC`, `PILATES`,
       `HOME_CARE`) — substituir por nova versão do enum
 
 ### Backend — Use Cases
 
-- [ ] `createTreatmentPlanUseCase`
-- [ ] `listPatientTreatmentPlansUseCase`
-- [ ] `getTreatmentPlanUseCase`
-- [ ] `updateTreatmentPlanUseCase`
-- [ ] `archiveTreatmentPlanUseCase`
-- [ ] `pauseTreatmentPlanUseCase`
-- [ ] `completeTreatmentPlanUseCase`
-- [ ] Atualizar `createSessionUseCase` para aceitar `treatmentPlanId?` (opcional)
+- [x] `createTreatmentPlanUseCase`
+- [x] `listPatientTreatmentPlansUseCase`
+- [x] `getTreatmentPlanUseCase`
+- [x] `updateTreatmentPlanUseCase`
+- [x] `archiveTreatmentPlanUseCase`
+- [x] `pauseTreatmentPlanUseCase`
+- [x] `completeTreatmentPlanUseCase`
+- [x] Atualizar `createSessionUseCase` para aceitar `treatmentPlanId?` (opcional)
   - se preenchido, valida ownership + que o plano não está `COMPLETED`/`CANCELED`
   - se preenchido, herda `area`/`workplaceId`/`attendanceType` do plano (overridable)
   - se omitido, sessão é avulsa (caminho permitido)
-- [ ] Atualizar `updateSessionUseCase` para aceitar mudança de plano
-- [ ] Multi-tenant: toda query de plan filtra por `userId`
+- [x] Atualizar `updateSessionUseCase` para aceitar mudança de plano
+- [x] Multi-tenant: toda query de plan filtra por `userId`
 
 ### Backend — HTTP
 
-- [ ] `POST /api/patients/:id/treatment-plans`
-- [ ] `GET /api/patients/:id/treatment-plans`
-- [ ] `GET /api/treatment-plans/:id`
-- [ ] `PUT /api/treatment-plans/:id`
-- [ ] `POST /api/treatment-plans/:id/pause`
-- [ ] `POST /api/treatment-plans/:id/complete`
-- [ ] `DELETE /api/treatment-plans/:id` (soft cancel via status `CANCELED`)
-- [ ] Atualizar `POST /api/sessions` e `PUT /api/sessions/:id` com `treatmentPlanId?`
+- [x] `POST /api/patients/:id/treatment-plans`
+- [x] `GET /api/patients/:id/treatment-plans`
+- [x] `GET /api/treatment-plans/:id`
+- [x] `PUT /api/treatment-plans/:id`
+- [x] `POST /api/treatment-plans/:id/pause`
+- [x] `POST /api/treatment-plans/:id/complete`
+- [x] `DELETE /api/treatment-plans/:id` (soft cancel via status `CANCELED`)
+- [x] Atualizar `POST /api/sessions` e `PUT /api/sessions/:id` com `treatmentPlanId?`
 
 ### Frontend
 
-- [ ] Remover campo "Área" do `PatientForm`
-- [ ] Remover badge de área da listagem `/pacientes` e da ficha
-- [ ] Adicionar seção "Planos de tratamento" na ficha `/pacientes/:id`:
+- [x] Remover campo "Área" do `PatientForm`
+- [x] Remover badge de área da listagem `/pacientes` e da ficha
+- [x] Adicionar seção "Planos de tratamento" na ficha `/pacientes/:id`:
   - Lista os planos com badge de área, especialidades, tipo, local, status
   - Botão "Novo plano"
   - Em cada plano: contador "X de Y sessões" (se PACKAGE) e ações editar/pausar/concluir
-- [ ] Página `/pacientes/:id/planos/novo` — formulário de criação de plano
-- [ ] Página `/pacientes/:id/planos/:planId/editar`
-- [ ] Componentes:
+- [x] Página `/pacientes/:id/planos/novo` — formulário de criação de plano
+- [x] Página `/pacientes/:id/planos/:planId/editar`
+- [x] Componentes:
   - `TreatmentPlanCard` (resumo do plano com badges)
   - `TreatmentPlanForm` (criar/editar)
   - `AreaBadge`, `SpecialtyBadges`, `AttendanceTypeBadge`
-- [ ] No `SessionForm`:
+- [x] No `SessionForm`:
   - Após escolher paciente, dropdown "Plano" com planos ativos do paciente +
     opção "Avulso"
   - Se plano selecionado, área/especialidades/local/tipo são pré-preenchidos
     (campos exibidos como herdados; podem ser sobrescritos individualmente)
   - Se "Avulso", os campos são preenchidos manualmente
-- [ ] No `SessionCard`, mostrar badge de plano (área + especialidades em forma compacta)
-  ou "Avulso"
+- [x] No `SessionCard`, mostrar badge de plano (área + especialidades em forma compacta)
+      ou "Avulso"
 
 ### Filtros e listagens
 
-- [ ] Atualizar filtros de `/pacientes` para permitir buscar por área **dos planos
-  ativos** (não mais `Patient.area`)
-- [ ] Atualizar filtros de `/atendimentos` para permitir filtrar por área e tipo de
-  atendimento usando os campos atuais da sessão
+- [x] Atualizar filtros de `/pacientes` para permitir buscar por área **dos planos
+      ativos** (não mais `Patient.area`)
+- [x] Atualizar filtros de `/atendimentos` para permitir filtrar por área e tipo de
+      atendimento usando os campos atuais da sessão
 
 ### Seed
 
-- [ ] Atualizar `prisma/seed.ts` para criar planos demonstrando multi-modalidade:
+- [x] Atualizar `prisma/seed.ts` para criar planos demonstrando multi-modalidade:
   - 1 paciente com 2 planos ativos: Ortopédica (per session) + Pilates (pacote)
   - 1 paciente apenas com plano Estética
   - 1 paciente sem plano (sessões avulsas)
-- [ ] Vincular sessões existentes do seed aos planos
+- [x] Vincular sessões existentes do seed aos planos
 
 ## Fora de Escopo
 
@@ -333,37 +333,37 @@ ALTER TABLE "Session" ALTER COLUMN "attendanceType" SET NOT NULL;
 
 ## UI
 
-- [ ] Página: `/pacientes/:id` (seção "Planos de tratamento")
-- [ ] Página: `/pacientes/:id/planos/novo`
-- [ ] Página: `/pacientes/:id/planos/:planId/editar`
-- [ ] Componente: `TreatmentPlanCard`
-- [ ] Componente: `TreatmentPlanForm`
-- [ ] Componente: `AreaBadge`
-- [ ] Componente: `SpecialtyBadges`
-- [ ] Componente: `AttendanceTypeBadge`
-- [ ] Atualizar: `PatientForm` (remover campo área)
-- [ ] Atualizar: `SessionForm` (seletor de plano + override)
-- [ ] Atualizar: `SessionCard` (badge de plano)
-- [ ] Atualizar: filtros em `/pacientes` e `/atendimentos`
+- [x] Página: `/pacientes/:id` (seção "Planos de tratamento")
+- [x] Página: `/pacientes/:id/planos/novo`
+- [x] Página: `/pacientes/:id/planos/:planId/editar`
+- [x] Componente: `TreatmentPlanCard`
+- [x] Componente: `TreatmentPlanForm`
+- [x] Componente: `AreaBadge`
+- [x] Componente: `SpecialtyBadges`
+- [x] Componente: `AttendanceTypeBadge`
+- [x] Atualizar: `PatientForm` (remover campo área)
+- [x] Atualizar: `SessionForm` (seletor de plano + override)
+- [x] Atualizar: `SessionCard` (badge de plano)
+- [x] Atualizar: filtros em `/pacientes` e `/atendimentos`
 
 ## Checklist Final
 
-- [ ] Migration `phase15a_treatment_plans` (adições) aplicada
-- [ ] Backfill executado e validado (todo paciente com sessões tem plano legado)
-- [ ] Migration `phase15b_drop_patient_area_and_session_type` aplicada
-- [ ] Patient sem campo `area`
-- [ ] Session sem campo `type`
-- [ ] Session com `workplaceId` e `attendanceType` NOT NULL
-- [ ] CRUD de plano funciona
-- [ ] `SessionForm` com seletor de plano (ou avulso)
-- [ ] Multi-tenant em todas as queries
-- [ ] Seed atualizado demonstrando multi-modalidade
-- [ ] `npm run lint` passa sem erros
-- [ ] `npm run build` passa sem erros
-- [ ] Testes unitários do módulo `treatment-plans`
-- [ ] `.docs/CONTEXT.md` atualizado
-- [ ] `README.md` atualizado
-- [ ] `.docs/CHANGELOG.md` atualizado
+- [x] Migration `phase15a_treatment_plans` (adições) criada
+- [x] Backfill implementado na migration (todo paciente com sessões recebe plano legado)
+- [x] Migration `phase15b_drop_patient_area_and_session_type` criada
+- [x] Patient sem campo `area`
+- [x] Session sem campo `type`
+- [x] Session com `workplaceId` e `attendanceType` NOT NULL
+- [x] CRUD de plano funciona
+- [x] `SessionForm` com seletor de plano (ou avulso)
+- [x] Multi-tenant em todas as queries
+- [x] Seed atualizado demonstrando multi-modalidade
+- [x] `npm run lint` passa sem erros
+- [x] `npm run build` passa sem erros
+- [x] Testes unitários do módulo `treatment-plans`
+- [x] `.docs/CONTEXT.md` atualizado
+- [x] `README.md` atualizado
+- [x] `.docs/CHANGELOG.md` atualizado
 - [ ] Validação manual no browser
 
 ## Notas para Próxima Sessão

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ PhysioFlow centraliza toda a operação clínica em uma interface única — do 
 - **Dashboard de KPIs** — Pacientes ativos, atendimentos semanais, alertas de inatividade
 - **Central de Documentos** — Geração de laudos e relatórios em PDF com dados do prontuário
 - **Logística Domiciliar** — Gestão de atendimentos fora da clínica com tags de prioridade
+- **Locais de Trabalho** — Cadastro de clínicas, particular e online com defaults próprios
+- **Planos de Tratamento** — Multi-modalidade por paciente, com área, especialidades,
+  modalidade, local e pacote/avulso preparatório para o financeiro
 
 ### Em desenvolvimento (ciclo Multi-modalidade + Financeiro)
 
-- **Locais de Trabalho** — Cadastro de clínicas, particular e online com defaults próprios
-- **Plano de Tratamento** — Cada paciente em N modalidades simultâneas (Pilates +
-  Ortopédica + Estética, etc.) com área, especialidades e tipo de atendimento por plano
 - **Pagamentos** — Registro de cobranças avulsas e pacotes com método e status
 - **Dashboard Financeiro** — Recebido vs previsto por dia/semana/mês e quebra por
   local/área
@@ -195,13 +195,14 @@ Após o seed:
 - Phase 14 — Locais de Trabalho (modelo `Workplace`, enums `WorkplaceKind`/`AttendanceType`,
   migration com backfill, CRUD `/configuracoes/locais`, seletor de local e modalidade no
   `SessionForm`, nome do local no `SessionCard`)
+- Phase 15 — Plano de Tratamento (modelo `TreatmentPlan`, multi-modalidade por paciente,
+  remoção de `Patient.area` e `Session.type`, CRUD/status de planos, seed multi-modalidade
+  e seletor de plano/avulso no `SessionForm`)
 
 ### 🗺️ Planejado — Ciclo "Multi-modalidade + Financeiro"
 
 > Decisão arquitetural: [ADR-005](.docs/decisions/ADR-005-multi-modalidade-financeiro.md)
 
-- **Phase 15 — Plano de Tratamento** (multi-modalidade por paciente, remoção do
-  `Patient.area` e `Session.type`, expansão de `TherapyArea`, novo enum `Specialty`)
 - **Phase 16 — Pagamentos** (`Payment`, `expectedFee` snapshot, avulso e pacote,
   saldo do plano)
 - **Phase 17 — Dashboard Financeiro** (recebido vs previsto, série temporal,
@@ -209,9 +210,8 @@ Após o seed:
 
 ### ➡️ Próximo Passo
 
-Iniciar **Phase 15**: modelo `TreatmentPlan` (1 paciente → N planos), backfill que cria
-plano legado por paciente, expansão de `TherapyArea`, novo enum `Specialty`. Remove
-`Patient.area` e `Session.type` (campos mantidos em coexistência desde a Phase 14).
+Iniciar **Phase 16**: pagamentos reais com `Payment`, snapshot `expectedFee` por sessão,
+cobranças avulsas e pacotes vinculados a `TreatmentPlan`.
 
 Ainda pendente do ciclo anterior: configurar as variáveis de e-mail/Google na Vercel e
 validar os fluxos reais de envio e sincronização.

--- a/prisma/migrations/20260425180000_phase15a_treatment_plans/migration.sql
+++ b/prisma/migrations/20260425180000_phase15a_treatment_plans/migration.sql
@@ -1,0 +1,174 @@
+-- Rename existing TherapyArea enum to legacy so we can recreate it with new values
+ALTER TYPE "TherapyArea" RENAME TO "TherapyAreaLegacy";
+
+-- CreateEnum
+CREATE TYPE "TherapyArea" AS ENUM (
+  'ORTOPEDICA',
+  'NEUROLOGICA',
+  'CARDIORESPIRATORIA',
+  'ESTETICA',
+  'ESPORTIVA',
+  'PELVICA',
+  'PEDIATRICA',
+  'GERIATRICA',
+  'PREVENTIVA',
+  'OUTRA'
+);
+
+-- CreateEnum
+CREATE TYPE "Specialty" AS ENUM (
+  'PILATES',
+  'RPG',
+  'ACUPUNTURA',
+  'LIBERACAO_MIOFASCIAL',
+  'VENTOSATERAPIA',
+  'DRY_NEEDLING',
+  'TERAPIA_MANUAL',
+  'OUTRA'
+);
+
+-- CreateEnum
+CREATE TYPE "PricingModel" AS ENUM ('PER_SESSION', 'PACKAGE');
+
+-- CreateEnum
+CREATE TYPE "PlanStatus" AS ENUM ('ACTIVE', 'COMPLETED', 'CANCELED', 'PAUSED');
+
+-- CreateTable
+CREATE TABLE "TreatmentPlan" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "patientId" TEXT NOT NULL,
+  "workplaceId" TEXT NOT NULL,
+  "area" "TherapyArea" NOT NULL,
+  "specialties" "Specialty"[] DEFAULT ARRAY[]::"Specialty"[],
+  "attendanceType" "AttendanceType" NOT NULL,
+  "pricingModel" "PricingModel" NOT NULL DEFAULT 'PER_SESSION',
+  "status" "PlanStatus" NOT NULL DEFAULT 'ACTIVE',
+  "sessionPrice" DECIMAL(10,2),
+  "totalSessions" INTEGER,
+  "packageAmount" DECIMAL(10,2),
+  "startsAt" TIMESTAMP(3),
+  "endsAt" TIMESTAMP(3),
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "TreatmentPlan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TreatmentPlan_userId_idx" ON "TreatmentPlan"("userId");
+CREATE INDEX "TreatmentPlan_userId_patientId_idx" ON "TreatmentPlan"("userId", "patientId");
+CREATE INDEX "TreatmentPlan_userId_status_idx" ON "TreatmentPlan"("userId", "status");
+CREATE INDEX "TreatmentPlan_userId_patientId_status_idx" ON "TreatmentPlan"("userId", "patientId", "status");
+
+-- AddForeignKey
+ALTER TABLE "TreatmentPlan" ADD CONSTRAINT "TreatmentPlan_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "TreatmentPlan" ADD CONSTRAINT "TreatmentPlan_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "TreatmentPlan" ADD CONSTRAINT "TreatmentPlan_workplaceId_fkey" FOREIGN KEY ("workplaceId") REFERENCES "Workplace"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AlterTable: add Session.treatmentPlanId (nullable for now)
+ALTER TABLE "Session" ADD COLUMN "treatmentPlanId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Session_userId_treatmentPlanId_idx" ON "Session"("userId", "treatmentPlanId");
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_treatmentPlanId_fkey" FOREIGN KEY ("treatmentPlanId") REFERENCES "TreatmentPlan"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Backfill: ensure every active user has a default workplace (already created in phase14, but be defensive)
+INSERT INTO "Workplace" (id, "userId", name, kind, "defaultAttendanceType", "isActive", "createdAt", "updatedAt")
+SELECT
+  gen_random_uuid()::text,
+  u.id,
+  'Meu consultório',
+  'OWN_CLINIC'::"WorkplaceKind",
+  'CLINIC'::"AttendanceType",
+  true,
+  now(),
+  now()
+FROM "User" u
+WHERE NOT EXISTS (
+  SELECT 1 FROM "Workplace" w WHERE w."userId" = u.id
+);
+
+-- Backfill: ensure every existing session has workplaceId and attendanceType (defensive)
+UPDATE "Session" s
+SET
+  "workplaceId" = w.id,
+  "attendanceType" = COALESCE(s."attendanceType", CASE s.type WHEN 'HOME_CARE'::"SessionType" THEN 'HOME_CARE'::"AttendanceType" ELSE 'CLINIC'::"AttendanceType" END)
+FROM (
+  SELECT DISTINCT ON ("userId") id, "userId"
+  FROM "Workplace"
+  WHERE "isActive" = true
+  ORDER BY "userId", "createdAt" ASC
+) w
+WHERE w."userId" = s."userId"
+  AND s."workplaceId" IS NULL;
+
+UPDATE "Session" s
+SET "attendanceType" = CASE s.type WHEN 'HOME_CARE'::"SessionType" THEN 'HOME_CARE'::"AttendanceType" ELSE 'CLINIC'::"AttendanceType" END
+WHERE s."attendanceType" IS NULL;
+
+-- Backfill: create one legacy TreatmentPlan per active patient that has at least one session
+WITH patient_default AS (
+  SELECT
+    p.id AS patient_id,
+    p."userId" AS user_id,
+    p.area::text AS old_area,
+    (
+      SELECT w.id
+      FROM "Workplace" w
+      WHERE w."userId" = p."userId" AND w."isActive" = true
+      ORDER BY w."createdAt" ASC
+      LIMIT 1
+    ) AS workplace_id,
+    COALESCE(
+      (
+        SELECT s."attendanceType"
+        FROM "Session" s
+        WHERE s."patientId" = p.id AND s."attendanceType" IS NOT NULL
+        GROUP BY s."attendanceType"
+        ORDER BY COUNT(*) DESC
+        LIMIT 1
+      ),
+      CASE WHEN p.area::text = 'HOME_CARE' THEN 'HOME_CARE'::"AttendanceType" ELSE 'CLINIC'::"AttendanceType" END
+    ) AS attendance_type
+  FROM "Patient" p
+  WHERE p."isActive" = true
+    AND EXISTS (SELECT 1 FROM "Session" s WHERE s."patientId" = p.id)
+    AND NOT EXISTS (SELECT 1 FROM "TreatmentPlan" tp WHERE tp."patientId" = p.id)
+)
+INSERT INTO "TreatmentPlan" (
+  id, "userId", "patientId", "workplaceId", area, specialties,
+  "attendanceType", "pricingModel", status, notes, "createdAt", "updatedAt"
+)
+SELECT
+  gen_random_uuid()::text,
+  pd.user_id,
+  pd.patient_id,
+  pd.workplace_id,
+  CASE pd.old_area
+    WHEN 'AESTHETIC' THEN 'ESTETICA'::"TherapyArea"
+    ELSE 'ORTOPEDICA'::"TherapyArea"
+  END,
+  CASE pd.old_area
+    WHEN 'PILATES' THEN ARRAY['PILATES']::"Specialty"[]
+    ELSE ARRAY[]::"Specialty"[]
+  END,
+  pd.attendance_type,
+  'PER_SESSION'::"PricingModel",
+  'ACTIVE'::"PlanStatus",
+  'Plano legado migrado de v14',
+  now(),
+  now()
+FROM patient_default pd
+WHERE pd.workplace_id IS NOT NULL;
+
+-- Link existing sessions to their patient's legacy plan
+UPDATE "Session" s
+SET "treatmentPlanId" = tp.id
+FROM "TreatmentPlan" tp
+WHERE tp."patientId" = s."patientId"
+  AND tp.notes = 'Plano legado migrado de v14'
+  AND s."treatmentPlanId" IS NULL;

--- a/prisma/migrations/20260425180001_phase15b_drop_legacy_fields/migration.sql
+++ b/prisma/migrations/20260425180001_phase15b_drop_legacy_fields/migration.sql
@@ -1,0 +1,17 @@
+-- Drop legacy Patient.area column (still typed as TherapyAreaLegacy after rename)
+ALTER TABLE "Patient" DROP COLUMN "area";
+
+-- Drop legacy enum
+DROP TYPE "TherapyAreaLegacy";
+
+-- Drop legacy Session.type column and its enum
+ALTER TABLE "Session" DROP COLUMN "type";
+DROP TYPE "SessionType";
+
+-- Make workplaceId and attendanceType non-nullable on Session
+ALTER TABLE "Session" ALTER COLUMN "workplaceId" SET NOT NULL;
+ALTER TABLE "Session" ALTER COLUMN "attendanceType" SET NOT NULL;
+
+-- Drop the old SET NULL FK from phase14 and re-add as RESTRICT (since now NOT NULL)
+ALTER TABLE "Session" DROP CONSTRAINT "Session_workplaceId_fkey";
+ALTER TABLE "Session" ADD CONSTRAINT "Session_workplaceId_fkey" FOREIGN KEY ("workplaceId") REFERENCES "Workplace"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,21 +15,45 @@ enum PatientClassification {
 }
 
 enum TherapyArea {
+  ORTOPEDICA
+  NEUROLOGICA
+  CARDIORESPIRATORIA
+  ESTETICA
+  ESPORTIVA
+  PELVICA
+  PEDIATRICA
+  GERIATRICA
+  PREVENTIVA
+  OUTRA
+}
+
+enum Specialty {
   PILATES
-  MOTOR
-  AESTHETIC
-  HOME_CARE
+  RPG
+  ACUPUNTURA
+  LIBERACAO_MIOFASCIAL
+  VENTOSATERAPIA
+  DRY_NEEDLING
+  TERAPIA_MANUAL
+  OUTRA
+}
+
+enum PricingModel {
+  PER_SESSION
+  PACKAGE
+}
+
+enum PlanStatus {
+  ACTIVE
+  COMPLETED
+  CANCELED
+  PAUSED
 }
 
 enum SessionStatus {
   AGENDADO
   REALIZADO
   CANCELADO
-}
-
-enum SessionType {
-  PRESENTIAL
-  HOME_CARE
 }
 
 enum DocumentType {
@@ -100,6 +124,7 @@ model User {
   calendarConnections CalendarConnection[]
   calendarEventLinks  CalendarEventLink[]
   workplaces          Workplace[]
+  treatmentPlans      TreatmentPlan[]
 }
 
 model Patient {
@@ -110,7 +135,6 @@ model Patient {
   phone            String?
   email            String?
   classification   PatientClassification @default(STANDARD)
-  area             TherapyArea
   notes            String?
   address          String?
   neighborhood     String?
@@ -126,6 +150,7 @@ model Patient {
   sessions       Session[]
   documents      Document[]
   emailMessages  EmailMessage[]
+  treatmentPlans TreatmentPlan[]
 
   @@unique([userId, email])
   @@index([userId])
@@ -145,27 +170,60 @@ model ClinicalRecord {
   patient Patient @relation(fields: [patientId], references: [id])
 }
 
+model TreatmentPlan {
+  id             String         @id @default(cuid())
+  userId         String
+  patientId      String
+  workplaceId    String
+  area           TherapyArea
+  specialties    Specialty[]    @default([])
+  attendanceType AttendanceType
+  pricingModel   PricingModel   @default(PER_SESSION)
+  status         PlanStatus     @default(ACTIVE)
+
+  sessionPrice  Decimal? @db.Decimal(10, 2)
+  totalSessions Int?
+  packageAmount Decimal? @db.Decimal(10, 2)
+
+  startsAt  DateTime?
+  endsAt    DateTime?
+  notes     String?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  user      User      @relation(fields: [userId], references: [id])
+  patient   Patient   @relation(fields: [patientId], references: [id])
+  workplace Workplace @relation(fields: [workplaceId], references: [id])
+  sessions  Session[]
+
+  @@index([userId])
+  @@index([userId, patientId])
+  @@index([userId, status])
+  @@index([userId, patientId, status])
+}
+
 model Session {
-  id         String        @id @default(cuid())
-  userId     String
-  patientId  String
-  date       DateTime
-  duration   Int
-  type           SessionType    @default(PRESENTIAL)
-  status         SessionStatus  @default(AGENDADO)
-  workplaceId    String?
-  attendanceType AttendanceType?
-  isActive       Boolean        @default(true)
-  subjective String?
-  objective  String?
-  assessment String?
-  plan       String?
-  createdAt  DateTime      @default(now())
-  updatedAt  DateTime      @updatedAt
+  id              String         @id @default(cuid())
+  userId          String
+  patientId       String
+  treatmentPlanId String?
+  date            DateTime
+  duration        Int
+  status          SessionStatus  @default(AGENDADO)
+  workplaceId     String
+  attendanceType  AttendanceType
+  isActive        Boolean        @default(true)
+  subjective      String?
+  objective       String?
+  assessment      String?
+  plan            String?
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
 
   user               User                @relation(fields: [userId], references: [id])
   patient            Patient             @relation(fields: [patientId], references: [id])
-  workplace          Workplace?          @relation(fields: [workplaceId], references: [id])
+  workplace          Workplace           @relation(fields: [workplaceId], references: [id])
+  treatmentPlan      TreatmentPlan?      @relation(fields: [treatmentPlanId], references: [id])
   emailMessages      EmailMessage[]
   calendarEventLinks CalendarEventLink[]
 
@@ -174,6 +232,7 @@ model Session {
   @@index([userId, date])
   @@index([userId, status])
   @@index([userId, isActive])
+  @@index([userId, treatmentPlanId])
 }
 
 model Workplace {
@@ -190,8 +249,9 @@ model Workplace {
   createdAt             DateTime       @default(now())
   updatedAt             DateTime       @updatedAt
 
-  user     User      @relation(fields: [userId], references: [id])
-  sessions Session[]
+  user           User            @relation(fields: [userId], references: [id])
+  sessions       Session[]
+  treatmentPlans TreatmentPlan[]
 
   @@index([userId])
   @@index([userId, isActive])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -28,6 +28,10 @@ async function main() {
     where: { user: { email: demoEmail } },
   })
 
+  await prisma.treatmentPlan.deleteMany({
+    where: { user: { email: demoEmail } },
+  })
+
   await prisma.calendarConnection.deleteMany({
     where: { user: { email: demoEmail } },
   })
@@ -71,7 +75,6 @@ async function main() {
       birthDate: new Date('1948-03-12T00:00:00.000Z'),
       phone: '(11) 99999-0001',
       classification: 'ELDERLY',
-      area: 'PILATES',
       notes: 'Paciente com boa adesão ao plano terapêutico.',
       clinicalRecord: {
         create: {
@@ -92,7 +95,6 @@ async function main() {
       phone: '(11) 99999-0002',
       email: 'carla.souza@exemplo.com',
       classification: 'STANDARD',
-      area: 'AESTHETIC',
       notes: 'Prefere atendimentos no período da manhã.',
       clinicalRecord: {
         create: {
@@ -113,7 +115,6 @@ async function main() {
       phone: '(11) 99999-0003',
       email: 'rafael.teixeira@exemplo.com',
       classification: 'PCD',
-      area: 'MOTOR',
       notes: 'Paciente em retorno gradual aos treinos.',
       clinicalRecord: {
         create: {
@@ -147,6 +148,49 @@ async function main() {
     },
   })
 
+  const gervasioOrtopedicaPlan = await prisma.treatmentPlan.create({
+    data: {
+      userId: user.id,
+      patientId: gervasio.id,
+      workplaceId: clinica.id,
+      area: 'ORTOPEDICA',
+      specialties: ['TERAPIA_MANUAL'],
+      attendanceType: 'CLINIC',
+      pricingModel: 'PER_SESSION',
+      sessionPrice: 180,
+      notes: 'Plano ortopedico para controle de dor lombar e manutencao funcional.',
+    },
+  })
+
+  const gervasioPilatesPlan = await prisma.treatmentPlan.create({
+    data: {
+      userId: user.id,
+      patientId: gervasio.id,
+      workplaceId: clinica.id,
+      area: 'ORTOPEDICA',
+      specialties: ['PILATES'],
+      attendanceType: 'CLINIC',
+      pricingModel: 'PACKAGE',
+      totalSessions: 10,
+      packageAmount: 1500,
+      notes: 'Pacote de Pilates terapeutico para estabilidade e prevencao.',
+    },
+  })
+
+  const carlaEsteticaPlan = await prisma.treatmentPlan.create({
+    data: {
+      userId: user.id,
+      patientId: carla.id,
+      workplaceId: particular.id,
+      area: 'ESTETICA',
+      specialties: ['LIBERACAO_MIOFASCIAL'],
+      attendanceType: 'HOME_CARE',
+      pricingModel: 'PER_SESSION',
+      sessionPrice: 220,
+      notes: 'Plano estetico com atendimento domiciliar e recursos manuais.',
+    },
+  })
+
   const now = new Date()
   const daysFromNow = (days: number, hour: number, minute = 0) => {
     const date = new Date(now)
@@ -167,9 +211,9 @@ async function main() {
       {
         userId: user.id,
         patientId: gervasio.id,
+        treatmentPlanId: gervasioOrtopedicaPlan.id,
         date: daysAgo(14, 9),
         duration: 60,
-        type: 'PRESENTIAL',
         status: 'REALIZADO',
         workplaceId: clinica.id,
         attendanceType: 'CLINIC',
@@ -182,9 +226,9 @@ async function main() {
       {
         userId: user.id,
         patientId: gervasio.id,
+        treatmentPlanId: gervasioPilatesPlan.id,
         date: daysAgo(7, 9),
         duration: 60,
-        type: 'PRESENTIAL',
         status: 'REALIZADO',
         workplaceId: clinica.id,
         attendanceType: 'CLINIC',
@@ -198,7 +242,6 @@ async function main() {
         patientId: rafael.id,
         date: daysAgo(2, 16, 30),
         duration: 50,
-        type: 'PRESENTIAL',
         status: 'REALIZADO',
         workplaceId: clinica.id,
         attendanceType: 'CLINIC',
@@ -210,9 +253,9 @@ async function main() {
       {
         userId: user.id,
         patientId: carla.id,
+        treatmentPlanId: carlaEsteticaPlan.id,
         date: daysFromNow(1, 8, 30),
         duration: 45,
-        type: 'HOME_CARE',
         status: 'AGENDADO',
         workplaceId: particular.id,
         attendanceType: 'HOME_CARE',
@@ -224,7 +267,6 @@ async function main() {
         patientId: rafael.id,
         date: daysFromNow(2, 15),
         duration: 50,
-        type: 'PRESENTIAL',
         status: 'AGENDADO',
         workplaceId: clinica.id,
         attendanceType: 'CLINIC',
@@ -233,9 +275,9 @@ async function main() {
       {
         userId: user.id,
         patientId: gervasio.id,
+        treatmentPlanId: gervasioPilatesPlan.id,
         date: daysFromNow(4, 10),
         duration: 60,
-        type: 'PRESENTIAL',
         status: 'CANCELADO',
         workplaceId: clinica.id,
         attendanceType: 'CLINIC',

--- a/src/app/(app)/agenda/page.tsx
+++ b/src/app/(app)/agenda/page.tsx
@@ -1,10 +1,7 @@
 import Link from 'next/link'
 import { CalendarCheck2, CalendarDays, Home } from 'lucide-react'
 import { getSession } from '@/lib/session'
-import {
-  formatAgendaDayLabel,
-  formatCalendarDateKey,
-} from '@/lib/date'
+import { formatAgendaDayLabel, formatCalendarDateKey } from '@/lib/date'
 import { SessionCard } from '@/components/sessions/SessionCard'
 import { DomiciliarToggle } from '@/components/agenda/DomiciliarToggle'
 import { AgendaViewToggle } from '@/components/agenda/AgendaViewToggle'
@@ -65,7 +62,7 @@ export default async function AgendaPage({
       to: to.toISOString(),
       limit: 500,
       order: 'asc',
-      ...(isHomeCareMode ? { type: 'HOME_CARE' } : {}),
+      ...(isHomeCareMode ? { attendanceType: 'HOME_CARE' } : {}),
     })
 
     const sessionsByDay = sessions.reduce<Record<string, typeof sessions>>((acc, item) => {
@@ -81,7 +78,7 @@ export default async function AgendaPage({
     }
 
     const todayKey = formatCalendarDateKey(new Date())
-    const homeCareCount = sessions.filter((item) => item.type === 'HOME_CARE').length
+    const homeCareCount = sessions.filter((item) => item.attendanceType === 'HOME_CARE').length
 
     return (
       <div className="space-y-6 sm:space-y-8">
@@ -108,10 +105,10 @@ export default async function AgendaPage({
     from: new Date().toISOString(),
     limit: 100,
     order: 'asc',
-    ...(isHomeCareMode ? { type: 'HOME_CARE' } : {}),
+    ...(isHomeCareMode ? { attendanceType: 'HOME_CARE' } : {}),
   })
 
-  const homeCareCount = sessions.filter((item) => item.type === 'HOME_CARE').length
+  const homeCareCount = sessions.filter((item) => item.attendanceType === 'HOME_CARE').length
 
   const groupedSessions = sessions.reduce<
     Array<{ key: string; label: string; items: typeof sessions }>
@@ -157,9 +154,7 @@ export default async function AgendaPage({
             </div>
             <div>
               <p className="font-display text-[22px] font-bold text-foreground">
-                {isHomeCareMode
-                  ? 'Nenhum atendimento domiciliar'
-                  : 'Nenhum agendamento futuro'}
+                {isHomeCareMode ? 'Nenhum atendimento domiciliar' : 'Nenhum agendamento futuro'}
               </p>
               <p className="mt-1 font-body text-[14px] text-muted-foreground">
                 {isHomeCareMode
@@ -183,7 +178,8 @@ export default async function AgendaPage({
                 <span className="rounded-full bg-accent-soft px-3 py-1 font-body text-[11px] font-semibold uppercase tracking-[0.14em] text-accent-soft-fg">
                   {group.label}
                 </span>
-                {!isHomeCareMode && group.items.some((item) => item.type === 'HOME_CARE') ? (
+                {!isHomeCareMode &&
+                group.items.some((item) => item.attendanceType === 'HOME_CARE') ? (
                   <span className="flex items-center gap-1 rounded-full bg-primary-soft px-3 py-1 font-body text-[11px] font-semibold text-primary-soft-fg">
                     <Home className="h-3.5 w-3.5" />
                     Inclui domiciliar
@@ -227,7 +223,11 @@ function AgendaHeader({
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <p className="font-body text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-            {isHomeCareMode ? 'Atendimentos Domiciliares' : view === 'calendar' ? 'Visão mensal' : 'Próximos'}
+            {isHomeCareMode
+              ? 'Atendimentos Domiciliares'
+              : view === 'calendar'
+                ? 'Visão mensal'
+                : 'Próximos'}
           </p>
           <h1 className="font-display text-[30px] font-bold leading-tight text-foreground sm:text-[36px]">
             Agenda

--- a/src/app/(app)/atendimentos/[id]/editar/page.tsx
+++ b/src/app/(app)/atendimentos/[id]/editar/page.tsx
@@ -8,13 +8,6 @@ import {
   SessionNotFoundError,
 } from '@/server/modules/sessions/application/get-session'
 
-const AREA_LABELS: Record<string, string> = {
-  PILATES: 'Pilates',
-  MOTOR: 'Fisioterapia Motora',
-  AESTHETIC: 'Fisioterapia Estética',
-  HOME_CARE: 'Atendimento Domiciliar',
-}
-
 async function loadSession(id: string, userId: string) {
   try {
     return await getSessionUseCase(id, userId)
@@ -66,8 +59,7 @@ export default async function EditarAtendimentoPage({
           <div className="flex items-center gap-2 self-start rounded-full bg-primary-soft px-3.5 py-2">
             <ClipboardEdit className="h-4 w-4 text-primary" />
             <span className="font-body text-[12px] font-semibold text-primary-soft-fg">
-              {clinicalSession.patient.name} •{' '}
-              {AREA_LABELS[clinicalSession.patient.area] ?? clinicalSession.patient.area}
+              {clinicalSession.patient.name}
             </span>
           </div>
         </div>
@@ -78,15 +70,16 @@ export default async function EditarAtendimentoPage({
         patient={{
           id: clinicalSession.patient.id,
           name: clinicalSession.patient.name,
-          area: clinicalSession.patient.area,
           email: clinicalSession.patient.email,
         }}
         initialValues={{
           id: clinicalSession.id,
           date: clinicalSession.date,
           duration: clinicalSession.duration,
-          type: clinicalSession.type,
+          treatmentPlanId: clinicalSession.treatmentPlanId,
           status: clinicalSession.status,
+          workplaceId: clinicalSession.workplaceId,
+          attendanceType: clinicalSession.attendanceType,
           subjective: clinicalSession.subjective,
           objective: clinicalSession.objective,
           assessment: clinicalSession.assessment,

--- a/src/app/(app)/documentos/page.tsx
+++ b/src/app/(app)/documentos/page.tsx
@@ -17,7 +17,7 @@ interface Document {
   patient: {
     id: string
     name: string
-    area: string
+    treatmentPlans?: Array<{ id: string; area: string; specialties: string[] }>
   }
 }
 
@@ -122,9 +122,7 @@ export default function DocumentosPage() {
       .catch(() => setEmailSettings(null))
   }, [])
 
-  const emailReady = Boolean(
-    emailSettings?.isEnabled && emailSettings?.hasAppPassword
-  )
+  const emailReady = Boolean(emailSettings?.isEnabled && emailSettings?.hasAppPassword)
 
   return (
     <div className="space-y-6 sm:space-y-8">

--- a/src/app/(app)/pacientes/[id]/editar/page.tsx
+++ b/src/app/(app)/pacientes/[id]/editar/page.tsx
@@ -56,7 +56,6 @@ export default async function EditarPacientePage({ params }: { params: Promise<{
           phone: patient.phone ?? '',
           email: patient.email ?? '',
           classification: patient.classification,
-          area: patient.area,
           notes: patient.notes ?? '',
           mainComplaint: patient.clinicalRecord?.mainComplaint ?? '',
           medicalHistory: patient.clinicalRecord?.medicalHistory ?? '',

--- a/src/app/(app)/pacientes/[id]/page.tsx
+++ b/src/app/(app)/pacientes/[id]/page.tsx
@@ -1,19 +1,23 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
-import { Calendar, ChevronLeft, Edit, FilePlus2, Mail, MapPin, Phone, TrendingUp } from 'lucide-react'
+import {
+  Calendar,
+  ChevronLeft,
+  Edit,
+  FilePlus2,
+  Mail,
+  MapPin,
+  Phone,
+  Plus,
+  TrendingUp,
+} from 'lucide-react'
 import { getSession } from '@/lib/session'
 import { formatDateOnlyPtBr } from '@/lib/date'
 import {
   getPatientUseCase,
   PatientNotFoundError,
 } from '@/server/modules/patients/application/get-patient'
-
-const AREA_LABELS: Record<string, string> = {
-  PILATES: 'Pilates',
-  MOTOR: 'Fisioterapia Motora',
-  AESTHETIC: 'Fisioterapia Estética',
-  HOME_CARE: 'Atendimento Domiciliar',
-}
+import { TreatmentPlanCard } from '@/components/treatment-plans/TreatmentPlanCard'
 
 const CLASSIFICATION_LABELS: Record<string, string> = {
   ELDERLY: 'Idoso',
@@ -32,13 +36,6 @@ const PRIORITY_COLORS: Record<string, string> = {
   NORMAL: 'bg-muted text-muted-foreground',
   HIGH: 'bg-warning-soft text-warning',
   URGENT: 'bg-[var(--color-accent)] text-white',
-}
-
-const AREA_COLORS: Record<string, string> = {
-  PILATES: 'bg-primary-soft text-primary-soft-fg',
-  MOTOR: 'bg-accent-soft text-accent-soft-fg',
-  AESTHETIC: 'bg-success-soft text-success',
-  HOME_CARE: 'bg-warning-soft text-warning',
 }
 
 function InfoRow({
@@ -101,6 +98,19 @@ export default async function FichaClinicaPage({ params }: { params: Promise<{ i
   }
 
   const birthFormatted = patient.birthDate ? formatDateOnlyPtBr(patient.birthDate) : null
+  const treatmentPlans = (patient.treatmentPlans ?? []).map((plan) => ({
+    ...plan,
+    sessionPrice: plan.sessionPrice?.toString() ?? null,
+    packageAmount: plan.packageAmount?.toString() ?? null,
+  }))
+  const hasHomeCarePlan = treatmentPlans.some((plan) => plan.attendanceType === 'HOME_CARE')
+  const hasHomeCareInfo = Boolean(
+    hasHomeCarePlan ||
+    patient.address ||
+    patient.neighborhood ||
+    patient.city ||
+    patient.homeCareNotes
+  )
 
   return (
     <div className="max-w-[1080px] space-y-6 sm:space-y-8">
@@ -125,13 +135,6 @@ export default async function FichaClinicaPage({ params }: { params: Promise<{ i
                 {patient.name}
               </h1>
               <div className="mt-2 flex flex-wrap items-center gap-2">
-                <span
-                  className={`rounded-full px-2.5 py-1 font-body text-[11px] font-semibold ${
-                    AREA_COLORS[patient.area] ?? 'bg-muted text-muted-foreground'
-                  }`}
-                >
-                  {AREA_LABELS[patient.area] ?? patient.area}
-                </span>
                 {patient.classification !== 'STANDARD' && (
                   <span className="px-2.5 py-1 rounded-full bg-danger-soft text-danger font-body text-[11px] font-semibold">
                     {CLASSIFICATION_LABELS[patient.classification]}
@@ -148,6 +151,13 @@ export default async function FichaClinicaPage({ params }: { params: Promise<{ i
             >
               <FilePlus2 className="h-4 w-4" />
               Registrar atendimento
+            </Link>
+            <Link
+              href={`/pacientes/${id}/planos/novo`}
+              className="flex w-full items-center justify-center gap-2 rounded-xl border border-border px-4 py-2.5 font-body text-[13px] font-semibold text-foreground transition-all hover:border-primary/40 hover:bg-primary-soft sm:w-auto"
+            >
+              <Plus className="h-4 w-4" />
+              Novo plano
             </Link>
             <Link
               href={`/pacientes/${id}/evolucao`}
@@ -198,7 +208,41 @@ export default async function FichaClinicaPage({ params }: { params: Promise<{ i
         </section>
       </div>
 
-      {patient.area === 'HOME_CARE' && (
+      <section className="space-y-4 rounded-[18px] border border-border bg-card p-5 sm:p-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="font-display font-bold text-[15px] text-foreground">
+              Planos de tratamento
+            </h2>
+            <p className="mt-1 font-body text-[12.5px] text-muted-foreground">
+              Modalidades ativas e pausadas vinculadas ao paciente.
+            </p>
+          </div>
+          <Link
+            href={`/pacientes/${id}/planos/novo`}
+            className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary px-4 py-2.5 font-body text-[13px] font-semibold text-primary-foreground shadow-glow transition-colors hover:bg-primary-hover sm:w-auto"
+          >
+            <Plus className="h-4 w-4" />
+            Novo plano
+          </Link>
+        </div>
+
+        {treatmentPlans.length === 0 ? (
+          <div className="rounded-[16px] border border-dashed border-border bg-background/70 px-4 py-6 text-center">
+            <p className="font-body text-[13px] text-muted-foreground">
+              Nenhum plano cadastrado. Atendimentos ainda podem ser avulsos.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {treatmentPlans.map((plan) => (
+              <TreatmentPlanCard key={plan.id} plan={plan} patientId={id} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {hasHomeCareInfo && (
         <section className="space-y-4 rounded-[18px] border border-border bg-card p-5 sm:p-6">
           <div className="flex items-center justify-between gap-3">
             <h2 className="font-display font-bold text-[15px] text-foreground">

--- a/src/app/(app)/pacientes/[id]/planos/[planId]/editar/page.tsx
+++ b/src/app/(app)/pacientes/[id]/planos/[planId]/editar/page.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ChevronLeft } from 'lucide-react'
+import { getSession } from '@/lib/session'
+import {
+  TreatmentPlanForm,
+  type TreatmentPlanFormInitialValues,
+} from '@/components/treatment-plans/TreatmentPlanForm'
+import {
+  getPatientUseCase,
+  PatientNotFoundError,
+} from '@/server/modules/patients/application/get-patient'
+import { getTreatmentPlanUseCase } from '@/server/modules/treatment-plans/application/get-treatment-plan'
+import { TreatmentPlanNotFoundError } from '@/server/modules/treatment-plans/domain/treatment-plan'
+
+async function loadPatient(id: string, userId: string) {
+  try {
+    return await getPatientUseCase(id, userId)
+  } catch (error) {
+    if (error instanceof PatientNotFoundError) return null
+    throw error
+  }
+}
+
+async function loadPlan(id: string, userId: string) {
+  try {
+    return await getTreatmentPlanUseCase(id, userId)
+  } catch (error) {
+    if (error instanceof TreatmentPlanNotFoundError) return null
+    throw error
+  }
+}
+
+export default async function EditarPlanoPage({
+  params,
+}: {
+  params: Promise<{ id: string; planId: string }>
+}) {
+  const { id, planId } = await params
+  const session = await getSession()
+  const patient = await loadPatient(id, session.userId!)
+  const plan = await loadPlan(planId, session.userId!)
+
+  if (!patient || !plan || plan.patientId !== id) {
+    notFound()
+  }
+
+  const initialValues: TreatmentPlanFormInitialValues = {
+    id: plan.id,
+    workplaceId: plan.workplaceId,
+    area: plan.area,
+    specialties: plan.specialties,
+    attendanceType: plan.attendanceType,
+    pricingModel: plan.pricingModel,
+    sessionPrice: plan.sessionPrice?.toString() ?? null,
+    totalSessions: plan.totalSessions,
+    packageAmount: plan.packageAmount?.toString() ?? null,
+    startsAt: plan.startsAt?.toISOString() ?? null,
+    endsAt: plan.endsAt?.toISOString() ?? null,
+    notes: plan.notes,
+  }
+
+  return (
+    <div className="max-w-[1040px] space-y-6 sm:space-y-8">
+      <div>
+        <Link
+          href={`/pacientes/${id}`}
+          className="mb-4 flex items-center gap-1.5 font-body text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+          Voltar para ficha clinica
+        </Link>
+        <p className="font-body text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          {patient.name}
+        </p>
+        <h1 className="font-display text-[30px] font-bold leading-tight text-foreground sm:text-[36px]">
+          Editar plano de tratamento
+        </h1>
+        <p className="mt-1 font-body text-[14px] text-muted-foreground">
+          Atualize area, local, modalidade e condicoes do plano.
+        </p>
+      </div>
+
+      <TreatmentPlanForm patientId={id} mode="edit" initialValues={initialValues} />
+    </div>
+  )
+}

--- a/src/app/(app)/pacientes/[id]/planos/novo/page.tsx
+++ b/src/app/(app)/pacientes/[id]/planos/novo/page.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ChevronLeft } from 'lucide-react'
+import { getSession } from '@/lib/session'
+import { TreatmentPlanForm } from '@/components/treatment-plans/TreatmentPlanForm'
+import {
+  getPatientUseCase,
+  PatientNotFoundError,
+} from '@/server/modules/patients/application/get-patient'
+
+async function loadPatient(id: string, userId: string) {
+  try {
+    return await getPatientUseCase(id, userId)
+  } catch (error) {
+    if (error instanceof PatientNotFoundError) return null
+    throw error
+  }
+}
+
+export default async function NovoPlanoPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const session = await getSession()
+  const patient = await loadPatient(id, session.userId!)
+
+  if (!patient) {
+    notFound()
+  }
+
+  return (
+    <div className="max-w-[1040px] space-y-6 sm:space-y-8">
+      <div>
+        <Link
+          href={`/pacientes/${id}`}
+          className="mb-4 flex items-center gap-1.5 font-body text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+          Voltar para ficha clinica
+        </Link>
+        <p className="font-body text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          {patient.name}
+        </p>
+        <h1 className="font-display text-[30px] font-bold leading-tight text-foreground sm:text-[36px]">
+          Novo plano de tratamento
+        </h1>
+        <p className="mt-1 font-body text-[14px] text-muted-foreground">
+          Cadastre uma modalidade ativa para organizar atendimentos e evolucao.
+        </p>
+      </div>
+
+      <TreatmentPlanForm patientId={id} />
+    </div>
+  )
+}

--- a/src/app/(app)/pacientes/[id]/sessoes/nova/page.tsx
+++ b/src/app/(app)/pacientes/[id]/sessoes/nova/page.tsx
@@ -8,13 +8,6 @@ import {
   PatientNotFoundError,
 } from '@/server/modules/patients/application/get-patient'
 
-const AREA_LABELS: Record<string, string> = {
-  PILATES: 'Pilates',
-  MOTOR: 'Fisioterapia Motora',
-  AESTHETIC: 'Fisioterapia Estética',
-  HOME_CARE: 'Atendimento Domiciliar',
-}
-
 async function loadPatient(id: string, userId: string) {
   try {
     return await getPatientUseCase(id, userId)
@@ -63,7 +56,7 @@ export default async function NovaSessaoPage({ params }: { params: Promise<{ id:
           <div className="flex items-center gap-2 self-start rounded-full bg-primary-soft px-3.5 py-2">
             <FilePlus2 className="h-4 w-4 text-primary" />
             <span className="font-body text-[12px] font-semibold text-primary-soft-fg">
-              {patient.name} • {AREA_LABELS[patient.area] ?? patient.area}
+              {patient.name}
             </span>
           </div>
         </div>
@@ -73,7 +66,6 @@ export default async function NovaSessaoPage({ params }: { params: Promise<{ id:
         patient={{
           id: patient.id,
           name: patient.name,
-          area: patient.area,
           email: patient.email,
         }}
       />

--- a/src/app/(app)/pacientes/page.tsx
+++ b/src/app/(app)/pacientes/page.tsx
@@ -59,7 +59,22 @@ async function PatientList({ searchParams }: { searchParams: SearchParams }) {
       </p>
       <div className="space-y-3">
         {patients.map((patient) => (
-          <PatientCard key={patient.id} patient={patient} />
+          <PatientCard
+            key={patient.id}
+            patient={{
+              id: patient.id,
+              name: patient.name,
+              phone: patient.phone,
+              birthDate: patient.birthDate ? patient.birthDate.toISOString() : null,
+              classification: patient.classification,
+              treatmentPlans: (patient.treatmentPlans ?? []).map((plan) => ({
+                id: plan.id,
+                area: plan.area,
+                specialties: plan.specialties,
+                status: plan.status,
+              })),
+            }}
+          />
         ))}
       </div>
     </div>

--- a/src/app/api/documents/[id]/download/route.ts
+++ b/src/app/api/documents/[id]/download/route.ts
@@ -20,6 +20,8 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ message: 'Documento não encontrado' }, { status: 404 })
     }
 
+    const primaryPlan = doc.patient.treatmentPlans?.[0] ?? null
+
     const buffer = await renderDocumentPDF({
       type: doc.type,
       userName: doc.user?.name ?? 'Fisioterapeuta',
@@ -27,7 +29,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
         name: doc.patient.name,
         birthDate: doc.patient.birthDate,
         phone: doc.patient.phone ?? undefined,
-        area: doc.patient.area,
+        area: primaryPlan?.area,
         classification: doc.patient.classification,
         clinicalRecord: doc.patient.clinicalRecord ?? undefined,
       },

--- a/src/app/api/patients/[id]/treatment-plans/route.ts
+++ b/src/app/api/patients/[id]/treatment-plans/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { PatientNotFoundError } from '@/server/modules/patients/application/get-patient'
+import {
+  createTreatmentPlanDTO,
+  listTreatmentPlansDTO,
+} from '@/server/modules/treatment-plans/http/treatment-plan.dto'
+import { createTreatmentPlanUseCase } from '@/server/modules/treatment-plans/application/create-treatment-plan'
+import { listPatientTreatmentPlansUseCase } from '@/server/modules/treatment-plans/application/list-treatment-plans'
+import { WorkplaceForPlanNotFoundError } from '@/server/modules/treatment-plans/domain/treatment-plan'
+
+type Params = { params: Promise<{ id: string }> }
+
+export async function GET(request: Request, { params }: Params) {
+  const session = await getSession()
+  if (!session.userId) {
+    return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+  }
+
+  const { id } = await params
+  const { searchParams } = new URL(request.url)
+  const parsed = listTreatmentPlansDTO.safeParse({
+    status: searchParams.get('status') ?? undefined,
+  })
+
+  if (!parsed.success) {
+    return NextResponse.json({ errors: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const result = await listPatientTreatmentPlansUseCase(session.userId, id, parsed.data)
+  return NextResponse.json(result)
+}
+
+export async function POST(request: Request, { params }: Params) {
+  const session = await getSession()
+  if (!session.userId) {
+    return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+  }
+
+  const { id } = await params
+  const body = await request.json()
+  const parsed = createTreatmentPlanDTO.safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json({ errors: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  try {
+    const plan = await createTreatmentPlanUseCase(session.userId, id, parsed.data)
+    return NextResponse.json({ plan }, { status: 201 })
+  } catch (error) {
+    if (error instanceof PatientNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    if (error instanceof WorkplaceForPlanNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ message: 'Erro interno' }, { status: 500 })
+  }
+}

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -8,6 +8,10 @@ import { updateSessionUseCase } from '@/server/modules/sessions/application/upda
 import { archiveSessionUseCase } from '@/server/modules/sessions/application/archive-session'
 import { updateSessionDTO } from '@/server/modules/sessions/http/session.dto'
 import { InvalidSessionScheduleError } from '@/server/modules/sessions/domain/session'
+import {
+  TreatmentPlanInactiveError,
+  TreatmentPlanNotFoundError,
+} from '@/server/modules/treatment-plans/domain/treatment-plan'
 
 type Params = { params: Promise<{ id: string }> }
 
@@ -56,6 +60,14 @@ export async function PUT(request: Request, { params }: Params) {
     }
 
     if (error instanceof InvalidSessionScheduleError) {
+      return NextResponse.json({ message: error.message }, { status: 400 })
+    }
+
+    if (error instanceof TreatmentPlanNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+
+    if (error instanceof TreatmentPlanInactiveError) {
       return NextResponse.json({ message: error.message }, { status: 400 })
     }
 

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -5,6 +5,10 @@ import { PatientNotFoundError } from '@/server/modules/patients/application/get-
 import { createSessionUseCase } from '@/server/modules/sessions/application/create-session'
 import { listSessionsUseCase } from '@/server/modules/sessions/application/list-sessions'
 import { InvalidSessionScheduleError } from '@/server/modules/sessions/domain/session'
+import {
+  TreatmentPlanInactiveError,
+  TreatmentPlanNotFoundError,
+} from '@/server/modules/treatment-plans/domain/treatment-plan'
 
 export async function GET(request: Request) {
   const session = await getSession()
@@ -16,8 +20,11 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const parsed = listSessionsDTO.safeParse({
     patientId: searchParams.get('patientId') ?? undefined,
+    treatmentPlanId: searchParams.get('treatmentPlanId') ?? undefined,
     status: searchParams.get('status') ?? undefined,
-    type: searchParams.get('type') ?? undefined,
+    attendanceType:
+      searchParams.get('attendanceType') ??
+      (searchParams.get('type') === 'HOME_CARE' ? 'HOME_CARE' : undefined),
     area: searchParams.get('area') ?? undefined,
     from: searchParams.get('from') ?? undefined,
     to: searchParams.get('to') ?? undefined,
@@ -56,6 +63,14 @@ export async function POST(request: Request) {
     }
 
     if (error instanceof InvalidSessionScheduleError) {
+      return NextResponse.json({ message: error.message }, { status: 400 })
+    }
+
+    if (error instanceof TreatmentPlanNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+
+    if (error instanceof TreatmentPlanInactiveError) {
       return NextResponse.json({ message: error.message }, { status: 400 })
     }
 

--- a/src/app/api/treatment-plans/[id]/complete/route.ts
+++ b/src/app/api/treatment-plans/[id]/complete/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { TreatmentPlanNotFoundError } from '@/server/modules/treatment-plans/domain/treatment-plan'
+import { completeTreatmentPlanUseCase } from '@/server/modules/treatment-plans/application/change-status'
+
+type Params = { params: Promise<{ id: string }> }
+
+export async function POST(_req: Request, { params }: Params) {
+  const session = await getSession()
+  if (!session.userId) return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+
+  const { id } = await params
+  try {
+    const plan = await completeTreatmentPlanUseCase(id, session.userId)
+    return NextResponse.json({ plan })
+  } catch (error) {
+    if (error instanceof TreatmentPlanNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ message: 'Erro interno' }, { status: 500 })
+  }
+}

--- a/src/app/api/treatment-plans/[id]/pause/route.ts
+++ b/src/app/api/treatment-plans/[id]/pause/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { TreatmentPlanNotFoundError } from '@/server/modules/treatment-plans/domain/treatment-plan'
+import { pauseTreatmentPlanUseCase } from '@/server/modules/treatment-plans/application/change-status'
+
+type Params = { params: Promise<{ id: string }> }
+
+export async function POST(_req: Request, { params }: Params) {
+  const session = await getSession()
+  if (!session.userId) return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+
+  const { id } = await params
+  try {
+    const plan = await pauseTreatmentPlanUseCase(id, session.userId)
+    return NextResponse.json({ plan })
+  } catch (error) {
+    if (error instanceof TreatmentPlanNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ message: 'Erro interno' }, { status: 500 })
+  }
+}

--- a/src/app/api/treatment-plans/[id]/resume/route.ts
+++ b/src/app/api/treatment-plans/[id]/resume/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { TreatmentPlanNotFoundError } from '@/server/modules/treatment-plans/domain/treatment-plan'
+import { resumeTreatmentPlanUseCase } from '@/server/modules/treatment-plans/application/change-status'
+
+type Params = { params: Promise<{ id: string }> }
+
+export async function POST(_req: Request, { params }: Params) {
+  const session = await getSession()
+  if (!session.userId) return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+
+  const { id } = await params
+  try {
+    const plan = await resumeTreatmentPlanUseCase(id, session.userId)
+    return NextResponse.json({ plan })
+  } catch (error) {
+    if (error instanceof TreatmentPlanNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ message: 'Erro interno' }, { status: 500 })
+  }
+}

--- a/src/app/api/treatment-plans/[id]/route.ts
+++ b/src/app/api/treatment-plans/[id]/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import {
+  TreatmentPlanNotFoundError,
+  WorkplaceForPlanNotFoundError,
+} from '@/server/modules/treatment-plans/domain/treatment-plan'
+import { getTreatmentPlanUseCase } from '@/server/modules/treatment-plans/application/get-treatment-plan'
+import { updateTreatmentPlanUseCase } from '@/server/modules/treatment-plans/application/update-treatment-plan'
+import { cancelTreatmentPlanUseCase } from '@/server/modules/treatment-plans/application/change-status'
+import { updateTreatmentPlanDTO } from '@/server/modules/treatment-plans/http/treatment-plan.dto'
+
+type Params = { params: Promise<{ id: string }> }
+
+export async function GET(_req: Request, { params }: Params) {
+  const session = await getSession()
+  if (!session.userId) return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+
+  const { id } = await params
+  try {
+    const plan = await getTreatmentPlanUseCase(id, session.userId)
+    return NextResponse.json({ plan })
+  } catch (error) {
+    if (error instanceof TreatmentPlanNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ message: 'Erro interno' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: Request, { params }: Params) {
+  const session = await getSession()
+  if (!session.userId) return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+
+  const { id } = await params
+  const body = await request.json()
+  const parsed = updateTreatmentPlanDTO.safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json({ errors: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  try {
+    const plan = await updateTreatmentPlanUseCase(id, session.userId, parsed.data)
+    return NextResponse.json({ plan })
+  } catch (error) {
+    if (error instanceof TreatmentPlanNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    if (error instanceof WorkplaceForPlanNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ message: 'Erro interno' }, { status: 500 })
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  const session = await getSession()
+  if (!session.userId) return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+
+  const { id } = await params
+  try {
+    const plan = await cancelTreatmentPlanUseCase(id, session.userId)
+    return NextResponse.json({ plan })
+  } catch (error) {
+    if (error instanceof TreatmentPlanNotFoundError) {
+      return NextResponse.json({ message: error.message }, { status: 404 })
+    }
+    return NextResponse.json({ message: 'Erro interno' }, { status: 500 })
+  }
+}

--- a/src/components/agenda/MonthCalendar.tsx
+++ b/src/components/agenda/MonthCalendar.tsx
@@ -10,7 +10,7 @@ type CalendarSession = {
   id: string
   date: Date | string
   duration: number
-  type: 'PRESENTIAL' | 'HOME_CARE'
+  attendanceType: string
   status: 'AGENDADO' | 'REALIZADO' | 'CANCELADO'
   subjective?: string | null
   objective?: string | null
@@ -19,7 +19,6 @@ type CalendarSession = {
   patient: {
     id: string
     name: string
-    area?: string
     homeCarePriority?: string | null
     address?: string | null
     neighborhood?: string | null
@@ -154,7 +153,7 @@ export function MonthCalendar({
           {days.map((day) => {
             const sessions = sessionsByDay[day.key] ?? []
             const total = sessions.length
-            const hasHomeCare = sessions.some((s) => s.type === 'HOME_CARE')
+            const hasHomeCare = sessions.some((s) => s.attendanceType === 'HOME_CARE')
             const isToday = day.key === todayKey
             const isSelected = day.key === selectedKey
 

--- a/src/components/dashboard/RecentSessions.tsx
+++ b/src/components/dashboard/RecentSessions.tsx
@@ -1,19 +1,13 @@
 import { StatusBadge } from '@/components/sessions/StatusBadge'
-import type { SessionStatus, SessionType, TherapyArea } from '@/generated/prisma/client'
+import type { SessionStatus } from '@/generated/prisma/client'
 import { formatTimePtBr, formatDateLongPtBr } from '@/lib/date'
-
-const AREA_LABELS: Record<TherapyArea, string> = {
-  PILATES: 'Pilates',
-  MOTOR: 'Motora',
-  AESTHETIC: 'Estética',
-  HOME_CARE: 'Domiciliar',
-}
+import { formatTreatmentPlanLabel } from '@/lib/clinical-labels'
 
 interface RecentSessionItem {
   id: string
   patientName: string
-  type: SessionType
-  area: TherapyArea
+  attendanceType: string
+  treatmentPlan: { area: string; specialties: string[] } | null
   date: string
   status: SessionStatus
   isHomeCare: boolean
@@ -30,14 +24,18 @@ export function RecentSessions({ sessions }: { sessions: RecentSessionItem[] }) 
         </p>
       ) : (
         <ul className="mt-4 divide-y divide-border">
-          {sessions.map(s => (
-            <li key={s.id} className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
+          {sessions.map((s) => (
+            <li
+              key={s.id}
+              className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0"
+            >
               <div className="min-w-0">
                 <p className="truncate font-body text-[15px] font-semibold text-foreground">
                   {s.patientName}
                 </p>
                 <p className="mt-0.5 font-body text-[12.5px] text-muted-foreground">
-                  {AREA_LABELS[s.area] ?? s.area} · {formatTimePtBr(s.date)} · {formatDateLongPtBr(s.date)}
+                  {formatTreatmentPlanLabel(s.treatmentPlan ?? undefined)} ·{' '}
+                  {formatTimePtBr(s.date)} · {formatDateLongPtBr(s.date)}
                 </p>
               </div>
 

--- a/src/components/documents/DocumentCard.tsx
+++ b/src/components/documents/DocumentCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { FileText, FilePlus, FileCheck, Download, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { formatTreatmentPlanLabel } from '@/lib/clinical-labels'
 
 const TYPE_LABELS: Record<string, string> = {
   LAUDO_FISIOTERAPEUTICO: 'Laudo Fisioterapêutico',
@@ -22,13 +23,6 @@ const TYPE_ICONS: Record<string, React.ElementType> = {
   DECLARACAO_COMPARECIMENTO: FileCheck,
 }
 
-const AREA_LABELS: Record<string, string> = {
-  PILATES: 'Pilates',
-  MOTOR: 'Motora',
-  AESTHETIC: 'Estética',
-  HOME_CARE: 'Domiciliar',
-}
-
 interface DocumentCardProps {
   document: {
     id: string
@@ -39,7 +33,7 @@ interface DocumentCardProps {
     patient: {
       id: string
       name: string
-      area: string
+      treatmentPlans?: Array<{ id: string; area: string; specialties: string[] }>
     }
   }
   onDelete: (id: string) => void
@@ -50,6 +44,7 @@ export function DocumentCard({ document: doc, onDelete }: DocumentCardProps) {
   const [confirming, setConfirming] = useState(false)
 
   const Icon = TYPE_ICONS[doc.type] ?? FileText
+  const primaryPlan = doc.patient.treatmentPlans?.[0] ?? null
   const date = new Date(doc.createdAt).toLocaleDateString('pt-BR', {
     day: '2-digit',
     month: '2-digit',
@@ -92,12 +87,14 @@ export function DocumentCard({ document: doc, onDelete }: DocumentCardProps) {
         </div>
 
         <div className="min-w-0 flex-1">
-          <p className="truncate font-body text-[15px] font-semibold text-foreground">{doc.title}</p>
+          <p className="truncate font-body text-[15px] font-semibold text-foreground">
+            {doc.title}
+          </p>
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="font-body text-[12px] text-muted-foreground">{doc.patient.name}</span>
             <span className="font-body text-[12px] text-muted-foreground">·</span>
             <span className="font-body text-[12px] text-muted-foreground">
-              {AREA_LABELS[doc.patient.area] ?? doc.patient.area}
+              {primaryPlan ? formatTreatmentPlanLabel(primaryPlan) : 'Sem plano'}
             </span>
             {doc.period && (
               <>

--- a/src/components/documents/NovoDocumentoModal.tsx
+++ b/src/components/documents/NovoDocumentoModal.tsx
@@ -15,7 +15,6 @@ const TYPE_OPTIONS = [
 interface Patient {
   id: string
   name: string
-  area: string
   email?: string | null
 }
 
@@ -106,9 +105,7 @@ export function NovoDocumentoModal({
         })
         if (!emailRes.ok) {
           const errData = await emailRes.json().catch(() => ({}))
-          setWarning(
-            `PDF gerado, mas o e-mail falhou: ${errData.message ?? 'erro desconhecido'}`
-          )
+          setWarning(`PDF gerado, mas o e-mail falhou: ${errData.message ?? 'erro desconhecido'}`)
           return
         }
       }
@@ -179,8 +176,7 @@ export function NovoDocumentoModal({
 
           <div className="space-y-1.5">
             <label className="flex items-center gap-1.5 font-body text-[13px] font-semibold text-foreground">
-              Período{' '}
-              <span className="font-normal text-muted-foreground">(opcional)</span>
+              Período <span className="font-normal text-muted-foreground">(opcional)</span>
               <PeriodInfoTooltip />
             </label>
             <input

--- a/src/components/patients/PatientCard.tsx
+++ b/src/components/patients/PatientCard.tsx
@@ -4,13 +4,7 @@ import Link from 'next/link'
 import { Phone, Calendar, ChevronRight } from 'lucide-react'
 import { formatDateOnlyPtBr } from '@/lib/date'
 import { cn } from '@/lib/utils'
-
-const AREA_LABELS: Record<string, string> = {
-  PILATES: 'Pilates',
-  MOTOR: 'Motora',
-  AESTHETIC: 'Estética',
-  HOME_CARE: 'Domiciliar',
-}
+import { formatTreatmentPlanLabel } from '@/lib/clinical-labels'
 
 const CLASSIFICATION_LABELS: Record<string, string> = {
   ELDERLY: 'Idoso',
@@ -19,20 +13,18 @@ const CLASSIFICATION_LABELS: Record<string, string> = {
   STANDARD: 'Padrão',
 }
 
-const AREA_COLORS: Record<string, string> = {
-  PILATES: 'bg-primary-soft text-primary-soft-fg',
-  MOTOR: 'bg-accent-soft text-accent-soft-fg',
-  AESTHETIC: 'bg-success-soft text-success',
-  HOME_CARE: 'bg-warning-soft text-warning',
-}
-
 interface Patient {
   id: string
   name: string
   phone: string | null
   birthDate: Date | string | null
   classification: string
-  area: string
+  treatmentPlans?: Array<{
+    id: string
+    area: string
+    specialties: string[]
+    status: string
+  }>
 }
 
 export function PatientCard({ patient }: { patient: Patient }) {
@@ -76,14 +68,19 @@ export function PatientCard({ patient }: { patient: Patient }) {
         </div>
 
         <div className="flex w-full flex-wrap items-center gap-2 lg:w-auto lg:justify-end">
-          <span
-            className={cn(
-              'rounded-full px-2.5 py-1 font-body text-[11px] font-semibold',
-              AREA_COLORS[patient.area] ?? 'bg-muted text-muted-foreground'
-            )}
-          >
-            {AREA_LABELS[patient.area] ?? patient.area}
-          </span>
+          {(patient.treatmentPlans ?? []).slice(0, 2).map((plan) => (
+            <span
+              key={plan.id}
+              className="rounded-full bg-primary-soft px-2.5 py-1 font-body text-[11px] font-semibold text-primary-soft-fg"
+            >
+              {formatTreatmentPlanLabel(plan)}
+            </span>
+          ))}
+          {(patient.treatmentPlans ?? []).length === 0 ? (
+            <span className="rounded-full bg-muted px-2.5 py-1 font-body text-[11px] font-semibold text-muted-foreground">
+              Sem plano
+            </span>
+          ) : null}
           {patient.classification !== 'STANDARD' && (
             <span className="rounded-full bg-danger-soft px-2.5 py-1 font-body text-[11px] font-semibold text-danger">
               {CLASSIFICATION_LABELS[patient.classification] ?? patient.classification}

--- a/src/components/patients/PatientFilters.tsx
+++ b/src/components/patients/PatientFilters.tsx
@@ -8,10 +8,16 @@ import { ThemedSelect } from '@/components/ui/themed-select'
 
 const AREAS = [
   { value: '', label: 'Todas as Áreas' },
-  { value: 'PILATES', label: 'Pilates' },
-  { value: 'MOTOR', label: 'Motora' },
-  { value: 'AESTHETIC', label: 'Estética' },
-  { value: 'HOME_CARE', label: 'Domiciliar' },
+  { value: 'ORTOPEDICA', label: 'Ortopedica' },
+  { value: 'NEUROLOGICA', label: 'Neurologica' },
+  { value: 'CARDIORESPIRATORIA', label: 'Cardiorrespiratoria' },
+  { value: 'ESTETICA', label: 'Estetica' },
+  { value: 'ESPORTIVA', label: 'Esportiva' },
+  { value: 'PELVICA', label: 'Pelvica' },
+  { value: 'PEDIATRICA', label: 'Pediatrica' },
+  { value: 'GERIATRICA', label: 'Geriatrica' },
+  { value: 'PREVENTIVA', label: 'Preventiva' },
+  { value: 'OUTRA', label: 'Outra' },
 ]
 
 const CLASSIFICATIONS = [

--- a/src/components/patients/PatientForm.tsx
+++ b/src/components/patients/PatientForm.tsx
@@ -13,7 +13,6 @@ interface PatientFormData {
   phone: string
   email: string
   classification: string
-  area: string
   notes: string
   mainComplaint: string
   medicalHistory: string
@@ -35,13 +34,6 @@ const HOME_CARE_PRIORITIES = [
   { value: 'NORMAL', label: 'Normal' },
   { value: 'HIGH', label: 'Prioritário' },
   { value: 'URGENT', label: 'Urgente' },
-]
-
-const AREAS = [
-  { value: 'PILATES', label: 'Pilates' },
-  { value: 'MOTOR', label: 'Fisioterapia Motora' },
-  { value: 'AESTHETIC', label: 'Fisioterapia Estética' },
-  { value: 'HOME_CARE', label: 'Atendimento Domiciliar' },
 ]
 
 const CLASSIFICATIONS = [
@@ -88,7 +80,6 @@ export function PatientForm({ initialData, patientId }: PatientFormProps) {
     phone: initialData?.phone ?? '',
     email: initialData?.email ?? '',
     classification: initialData?.classification ?? 'STANDARD',
-    area: initialData?.area ?? '',
     notes: initialData?.notes ?? '',
     mainComplaint: initialData?.mainComplaint ?? '',
     medicalHistory: initialData?.medicalHistory ?? '',
@@ -208,15 +199,6 @@ export function PatientForm({ initialData, patientId }: PatientFormProps) {
         </h2>
 
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <Field label="Área terapêutica *" error={errors.area}>
-            <ThemedSelect
-              value={form.area}
-              onChange={(next) => set('area', next)}
-              options={[{ value: '', label: 'Selecionar área' }, ...AREAS]}
-              ariaLabel="Área terapêutica"
-            />
-          </Field>
-
           <Field label="Classificação" error={errors.classification}>
             <ThemedSelect
               value={form.classification}
@@ -284,11 +266,6 @@ export function PatientForm({ initialData, patientId }: PatientFormProps) {
           <h2 className="font-display font-bold text-[16px] text-foreground">
             Logística Domiciliar
           </h2>
-          {form.area === 'HOME_CARE' && (
-            <span className="rounded-full bg-warning-soft px-2.5 py-1 font-body text-[11px] font-semibold text-warning">
-              HOME CARE
-            </span>
-          )}
         </div>
 
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -18,25 +18,33 @@ import {
   UserRound,
   X,
 } from 'lucide-react'
-import type { SessionStatus, SessionType } from '@/generated/prisma/client'
+import type { SessionStatus } from '@/generated/prisma/client'
 import { formatDateLongPtBr, formatTimePtBr } from '@/lib/date'
 import { cn } from '@/lib/utils'
 import { StatusBadge } from '@/components/sessions/StatusBadge'
-import { SESSION_TYPE_LABELS } from '@/components/sessions/session-meta'
 import { CalendarSyncBadge } from '@/components/calendar/CalendarSyncBadge'
+import { ATTENDANCE_TYPE_LABELS, formatTreatmentPlanLabel } from '@/lib/clinical-labels'
 
 interface SessionCardProps {
   session: {
     id: string
     date: Date | string
     duration: number
-    type: SessionType
+    attendanceType: string
     status: SessionStatus
     subjective?: string | null
     objective?: string | null
     assessment?: string | null
     plan?: string | null
     workplace?: { id: string; name: string } | null
+    treatmentPlan?: {
+      id: string
+      area: string
+      specialties: string[]
+      attendanceType: string
+      status: string
+      pricingModel: string
+    } | null
     calendarEventLinks?: Array<{
       id: string
       status: string
@@ -114,6 +122,7 @@ export function SessionCard({
   const calendarLink = session.calendarEventLinks?.[0]
   const isScheduled = session.status === 'AGENDADO'
   const isSynced = calendarLink?.status === 'SYNCED'
+  const isHomeCare = session.attendanceType === 'HOME_CARE'
 
   useEffect(() => {
     if (allowStatusActions && isScheduled && !emailSettings) {
@@ -251,32 +260,35 @@ export function SessionCard({
             </Link>
 
             <div className="flex flex-wrap items-center gap-2">
-              {session.type === 'HOME_CARE' ? (
+              {isHomeCare ? (
                 <span className="rounded-full bg-accent-soft px-2.5 py-1 font-body text-[11px] font-semibold text-accent-soft-fg">
                   Domiciliar
                 </span>
               ) : null}
-              {session.type === 'HOME_CARE' && session.patient.homeCarePriority === 'URGENT' ? (
+              {isHomeCare && session.patient.homeCarePriority === 'URGENT' ? (
                 <span className="rounded-full bg-[var(--color-accent)] px-2.5 py-1 font-body text-[11px] font-semibold uppercase tracking-wide text-white">
                   Urgente
                 </span>
-              ) : session.type === 'HOME_CARE' && session.patient.homeCarePriority === 'HIGH' ? (
+              ) : isHomeCare && session.patient.homeCarePriority === 'HIGH' ? (
                 <span className="rounded-full bg-warning-soft px-2.5 py-1 font-body text-[11px] font-semibold text-warning">
                   Prioritário
                 </span>
               ) : null}
+              <span className="rounded-full bg-muted px-2.5 py-1 font-body text-[11px] font-semibold text-muted-foreground">
+                {session.treatmentPlan ? formatTreatmentPlanLabel(session.treatmentPlan) : 'Avulso'}
+              </span>
               <StatusBadge status={session.status} />
               <CalendarSyncBadge status={calendarLink?.status} />
             </div>
 
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 font-body text-[12px] text-muted-foreground">
               <span className="flex items-center gap-1.5">
-                {session.type === 'HOME_CARE' ? (
+                {isHomeCare ? (
                   <Home className="h-3.5 w-3.5" />
                 ) : (
                   <UserRound className="h-3.5 w-3.5" />
                 )}
-                {session.type === 'HOME_CARE' ? 'Atendimento domiciliar' : SESSION_TYPE_LABELS[session.type]}
+                {ATTENDANCE_TYPE_LABELS[session.attendanceType] ?? session.attendanceType}
               </span>
               {!showDate ? (
                 <span className="flex items-center gap-1.5">

--- a/src/components/sessions/SessionForm.tsx
+++ b/src/components/sessions/SessionForm.tsx
@@ -8,9 +8,9 @@ import { formatDateTimeLocalInputValue } from '@/lib/date'
 import { cn } from '@/lib/utils'
 import { DateTimePicker } from '@/components/ui/datetime-picker'
 import { ThemedSelect } from '@/components/ui/themed-select'
+import { ATTENDANCE_TYPE_LABELS, formatTreatmentPlanLabel } from '@/lib/clinical-labels'
 
 type SessionStatus = 'AGENDADO' | 'REALIZADO' | 'CANCELADO'
-type SessionType = 'PRESENTIAL' | 'HOME_CARE'
 type AttendanceType = 'CLINIC' | 'HOME_CARE' | 'HOSPITAL' | 'CORPORATE' | 'ONLINE'
 
 interface WorkplaceSummary {
@@ -22,7 +22,7 @@ interface WorkplaceSummary {
 interface SessionFormData {
   date: string
   duration: string
-  type: SessionType
+  treatmentPlanId: string
   status: SessionStatus
   workplaceId: string
   attendanceType: AttendanceType
@@ -37,7 +37,7 @@ export interface SessionFormInitialValues {
   id: string
   date: Date | string
   duration: number
-  type: SessionType
+  treatmentPlanId?: string | null
   status: SessionStatus
   workplaceId?: string | null
   attendanceType?: AttendanceType | null
@@ -52,7 +52,6 @@ interface SessionFormProps {
   patient: {
     id: string
     name: string
-    area: string
     email?: string | null
   }
   mode?: 'create' | 'edit'
@@ -65,17 +64,22 @@ interface EmailSummary {
   sendSessionRemindersByDefault: boolean
 }
 
-const sessionTypeOptions: Array<{ value: SessionType; label: string }> = [
-  { value: 'PRESENTIAL', label: 'Presencial' },
-  { value: 'HOME_CARE', label: 'Domiciliar' },
-]
+interface TreatmentPlanSummary {
+  id: string
+  area: string
+  specialties: string[]
+  attendanceType: AttendanceType
+  workplaceId: string
+  workplace?: { id: string; name: string } | null
+  status: string
+}
 
 const attendanceTypeOptions: Array<{ value: AttendanceType; label: string }> = [
-  { value: 'CLINIC', label: 'Clínica' },
-  { value: 'HOME_CARE', label: 'Domiciliar' },
-  { value: 'HOSPITAL', label: 'Hospital' },
-  { value: 'CORPORATE', label: 'Corporativo' },
-  { value: 'ONLINE', label: 'Online' },
+  { value: 'CLINIC', label: ATTENDANCE_TYPE_LABELS.CLINIC },
+  { value: 'HOME_CARE', label: ATTENDANCE_TYPE_LABELS.HOME_CARE },
+  { value: 'HOSPITAL', label: ATTENDANCE_TYPE_LABELS.HOSPITAL },
+  { value: 'CORPORATE', label: ATTENDANCE_TYPE_LABELS.CORPORATE },
+  { value: 'ONLINE', label: ATTENDANCE_TYPE_LABELS.ONLINE },
 ]
 
 const createStatusOptions: Array<{ value: SessionStatus; label: string }> = [
@@ -122,15 +126,12 @@ function buildDefaultDate() {
   return formatDateTimeLocalInputValue(date)
 }
 
-function buildInitialFormData(
-  patient: SessionFormProps['patient'],
-  initialValues?: SessionFormInitialValues
-): SessionFormData {
+function buildInitialFormData(initialValues?: SessionFormInitialValues): SessionFormData {
   if (initialValues) {
     return {
       date: formatDateTimeLocalInputValue(new Date(initialValues.date)),
       duration: String(initialValues.duration),
-      type: initialValues.type,
+      treatmentPlanId: initialValues.treatmentPlanId ?? '',
       status: initialValues.status,
       workplaceId: initialValues.workplaceId ?? '',
       attendanceType: initialValues.attendanceType ?? 'CLINIC',
@@ -145,10 +146,10 @@ function buildInitialFormData(
   return {
     date: buildDefaultDate(),
     duration: '50',
-    type: patient.area === 'HOME_CARE' ? 'HOME_CARE' : 'PRESENTIAL',
+    treatmentPlanId: '',
     status: 'AGENDADO',
     workplaceId: '',
-    attendanceType: patient.area === 'HOME_CARE' ? 'HOME_CARE' : 'CLINIC',
+    attendanceType: 'CLINIC',
     subjective: '',
     objective: '',
     assessment: '',
@@ -187,9 +188,7 @@ const inputClass = cn(
 export function SessionForm({ patient, mode = 'create', initialValues }: SessionFormProps) {
   const router = useRouter()
   const isEdit = mode === 'edit' && Boolean(initialValues)
-  const [form, setForm] = useState<SessionFormData>(() =>
-    buildInitialFormData(patient, initialValues)
-  )
+  const [form, setForm] = useState<SessionFormData>(() => buildInitialFormData(initialValues))
   const [errors, setErrors] = useState<Partial<Record<keyof SessionFormData, string>>>({})
   const [serverError, setServerError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -198,6 +197,7 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
   const [calendarConnected, setCalendarConnected] = useState(false)
   const [loadingCalendarSettings, setLoadingCalendarSettings] = useState(true)
   const [workplaces, setWorkplaces] = useState<WorkplaceSummary[]>([])
+  const [treatmentPlans, setTreatmentPlans] = useState<TreatmentPlanSummary[]>([])
 
   useEffect(() => {
     fetch('/api/workplaces')
@@ -210,13 +210,37 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
           setForm((prev) => ({
             ...prev,
             workplaceId: first.id,
-            attendanceType: prev.attendanceType !== 'CLINIC' ? prev.attendanceType : first.defaultAttendanceType,
+            attendanceType:
+              prev.attendanceType !== 'CLINIC' ? prev.attendanceType : first.defaultAttendanceType,
           }))
         }
       })
       .catch(() => undefined)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEdit])
+
+  useEffect(() => {
+    fetch(`/api/patients/${patient.id}/treatment-plans`)
+      .then((response) => response.json())
+      .then((data) => {
+        const list: TreatmentPlanSummary[] = data.plans ?? []
+        setTreatmentPlans(list)
+
+        if (!isEdit && !form.treatmentPlanId) {
+          const firstActive = list.find((plan) => plan.status === 'ACTIVE')
+          if (firstActive) {
+            setForm((previous) => ({
+              ...previous,
+              treatmentPlanId: firstActive.id,
+              workplaceId: firstActive.workplaceId,
+              attendanceType: firstActive.attendanceType,
+            }))
+          }
+        }
+      })
+      .catch(() => undefined)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [patient.id, isEdit])
 
   useEffect(() => {
     fetch('/api/settings/email')
@@ -240,6 +264,7 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
   const patientHasEmail = Boolean(patient.email)
   const canSendReminder = emailReady && patientHasEmail
   const statusOptions = isEdit ? editStatusOptions : createStatusOptions
+  const selectedPlan = treatmentPlans.find((plan) => plan.id === form.treatmentPlanId) ?? null
 
   function set<K extends keyof SessionFormData>(key: K, value: SessionFormData[K]) {
     setForm((previous) => ({ ...previous, [key]: value }))
@@ -275,7 +300,7 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
       const body: Record<string, unknown> = {
         date: new Date(form.date).toISOString(),
         duration: Number(form.duration),
-        type: form.type,
+        treatmentPlanId: form.treatmentPlanId || (isEdit ? null : undefined),
         status: form.status,
         workplaceId: form.workplaceId || undefined,
         attendanceType: form.attendanceType || undefined,
@@ -356,8 +381,8 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
             </h2>
             <p className="mt-1 font-body text-[13px] text-muted-foreground">
               {isEdit
-                ? 'Atualize data, duração, tipo e status do atendimento.'
-                : 'Registre data, duração, tipo e status inicial da sessão.'}
+                ? 'Atualize data, plano, modalidade e status do atendimento.'
+                : 'Registre data, plano, modalidade e status inicial da sessao.'}
             </p>
           </div>
           <div className="rounded-full bg-primary-soft px-3 py-1.5 font-body text-[11px] font-semibold text-primary-soft-fg">
@@ -381,12 +406,28 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
             />
           </Field>
 
-          <Field label="Tipo *" error={errors.type}>
+          <Field label="Plano" error={errors.treatmentPlanId}>
             <ThemedSelect
-              value={form.type}
-              onChange={(next) => set('type', next as SessionType)}
-              options={sessionTypeOptions}
-              ariaLabel="Tipo de atendimento"
+              value={form.treatmentPlanId}
+              onChange={(next) => {
+                set('treatmentPlanId', next)
+                const plan = treatmentPlans.find((item) => item.id === next)
+                if (plan) {
+                  setForm((previous) => ({
+                    ...previous,
+                    treatmentPlanId: plan.id,
+                    workplaceId: plan.workplaceId,
+                    attendanceType: plan.attendanceType,
+                  }))
+                }
+              }}
+              options={[
+                { value: '', label: 'Avulso' },
+                ...treatmentPlans
+                  .filter((plan) => plan.status === 'ACTIVE' || plan.id === form.treatmentPlanId)
+                  .map((plan) => ({ value: plan.id, label: formatTreatmentPlanLabel(plan) })),
+              ]}
+              ariaLabel="Plano de tratamento"
             />
           </Field>
 
@@ -409,7 +450,7 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
                   if (selected) set('attendanceType', selected.defaultAttendanceType)
                 }}
                 options={[
-                  { value: '', label: 'Sem local específico' },
+                  { value: '', label: 'Selecionar local' },
                   ...workplaces.map((w) => ({ value: w.id, label: w.name })),
                 ]}
                 ariaLabel="Local de trabalho"
@@ -426,6 +467,27 @@ export function SessionForm({ patient, mode = 'create', initialValues }: Session
             />
           </Field>
         </div>
+
+        {selectedPlan ? (
+          <div className="rounded-[16px] border border-primary/20 bg-primary-soft/50 px-4 py-3">
+            <p className="font-body text-[12px] font-semibold text-primary-soft-fg">
+              Herdado do plano: {formatTreatmentPlanLabel(selectedPlan)}
+            </p>
+            <p className="mt-1 font-body text-[12px] text-muted-foreground">
+              Local e modalidade foram preenchidos pelo plano e podem ser ajustados para esta
+              sessao.
+            </p>
+          </div>
+        ) : (
+          <div className="rounded-[16px] border border-border bg-background/70 px-4 py-3">
+            <p className="font-body text-[12px] font-semibold text-foreground">
+              Atendimento avulso
+            </p>
+            <p className="mt-1 font-body text-[12px] text-muted-foreground">
+              Esta sessao ficara sem plano vinculado.
+            </p>
+          </div>
+        )}
 
         <div className="rounded-[18px] border border-border bg-background/70 p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/src/components/sessions/session-meta.ts
+++ b/src/components/sessions/session-meta.ts
@@ -1,12 +1,7 @@
-import type { SessionStatus, SessionType } from '@/generated/prisma/client'
+import type { SessionStatus } from '@/generated/prisma/client'
 
 export const SESSION_STATUS_LABELS: Record<SessionStatus, string> = {
   AGENDADO: 'Agendado',
   REALIZADO: 'Realizado',
   CANCELADO: 'Cancelado',
-}
-
-export const SESSION_TYPE_LABELS: Record<SessionType, string> = {
-  PRESENTIAL: 'Atendimento presencial',
-  HOME_CARE: 'Atendimento domiciliar',
 }

--- a/src/components/timeline/TimelineEntry.tsx
+++ b/src/components/timeline/TimelineEntry.tsx
@@ -1,5 +1,5 @@
 import { Home } from 'lucide-react'
-import type { SessionStatus, SessionType } from '@/generated/prisma/client'
+import type { SessionStatus } from '@/generated/prisma/client'
 import { formatDateLongPtBr, formatTimePtBr } from '@/lib/date'
 import { cn } from '@/lib/utils'
 import { StatusBadge } from '@/components/sessions/StatusBadge'
@@ -16,7 +16,7 @@ interface TimelineEntryProps {
     id: string
     date: Date | string
     duration: number
-    type: SessionType
+    attendanceType: string
     status: SessionStatus
     subjective?: string | null
     objective?: string | null
@@ -28,9 +28,10 @@ interface TimelineEntryProps {
 
 export function TimelineEntry({ session, isLast = false }: TimelineEntryProps) {
   const hasContent = [session.subjective, session.objective, session.assessment, session.plan].some(
-    v => v && v.trim().length > 0
+    (v) => v && v.trim().length > 0
   )
   const defaultOpen = session.status === 'REALIZADO' && hasContent
+  const isHomeCare = session.attendanceType === 'HOME_CARE'
 
   return (
     <div className="relative flex gap-4 pb-6">
@@ -58,7 +59,7 @@ export function TimelineEntry({ session, isLast = false }: TimelineEntryProps) {
               <span>{formatTimePtBr(session.date)}</span>
               <span>·</span>
               <span>{session.duration} min</span>
-              {session.type === 'HOME_CARE' && (
+              {isHomeCare && (
                 <>
                   <span>·</span>
                   <span className="flex items-center gap-1">
@@ -71,7 +72,7 @@ export function TimelineEntry({ session, isLast = false }: TimelineEntryProps) {
           </div>
 
           <div className="flex items-center gap-2">
-            {session.type === 'HOME_CARE' && (
+            {isHomeCare && (
               <span className="rounded-full bg-accent-soft px-2.5 py-1 font-body text-[11px] font-semibold text-accent-soft-fg">
                 Domiciliar
               </span>

--- a/src/components/treatment-plans/TreatmentPlanCard.tsx
+++ b/src/components/treatment-plans/TreatmentPlanCard.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useState, useTransition } from 'react'
+import {
+  CheckCircle2,
+  CircleDollarSign,
+  MapPin,
+  Pause,
+  Pencil,
+  Play,
+  Stethoscope,
+  XCircle,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  ATTENDANCE_TYPE_LABELS,
+  PLAN_STATUS_LABELS,
+  PRICING_MODEL_LABELS,
+  formatSpecialties,
+  formatTreatmentPlanLabel,
+} from '@/lib/clinical-labels'
+
+export interface TreatmentPlanCardData {
+  id: string
+  patientId?: string
+  area: string
+  specialties: string[]
+  attendanceType: string
+  pricingModel: string
+  status: string
+  sessionPrice?: unknown
+  packageAmount?: unknown
+  totalSessions?: number | null
+  notes?: string | null
+  workplace?: { id: string; name: string } | null
+  _count?: { sessions: number }
+}
+
+interface TreatmentPlanCardProps {
+  plan: TreatmentPlanCardData
+  patientId: string
+  showActions?: boolean
+}
+
+const STATUS_CLASSES: Record<string, string> = {
+  ACTIVE: 'bg-primary-soft text-primary-soft-fg',
+  PAUSED: 'bg-warning-soft text-warning',
+  COMPLETED: 'bg-success-soft text-success',
+  CANCELED: 'bg-danger-soft text-danger',
+}
+
+function money(value: unknown) {
+  if (value === null || value === undefined || value === '') return null
+  const numberValue = typeof value === 'number' ? value : Number(value)
+  if (Number.isNaN(numberValue)) return null
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  }).format(numberValue)
+}
+
+export function TreatmentPlanCard({ plan, patientId, showActions = true }: TreatmentPlanCardProps) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [busyAction, setBusyAction] = useState<string | null>(null)
+  const specialtyText = formatSpecialties(plan.specialties)
+  const sessionCount = plan._count?.sessions ?? 0
+
+  async function mutate(action: 'pause' | 'resume' | 'complete' | 'cancel') {
+    setBusyAction(action)
+    const url =
+      action === 'cancel'
+        ? `/api/treatment-plans/${plan.id}`
+        : `/api/treatment-plans/${plan.id}/${action}`
+    const method = action === 'cancel' ? 'DELETE' : 'POST'
+
+    try {
+      const response = await fetch(url, { method })
+      if (response.ok) {
+        startTransition(() => router.refresh())
+      }
+    } finally {
+      setBusyAction(null)
+    }
+  }
+
+  return (
+    <article className="rounded-[18px] border border-border bg-card p-4 shadow-sm sm:p-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-primary-soft px-2.5 py-1 font-body text-[11px] font-semibold text-primary-soft-fg">
+              {formatTreatmentPlanLabel(plan)}
+            </span>
+            <span
+              className={cn(
+                'rounded-full px-2.5 py-1 font-body text-[11px] font-semibold',
+                STATUS_CLASSES[plan.status] ?? 'bg-muted text-muted-foreground'
+              )}
+            >
+              {PLAN_STATUS_LABELS[plan.status] ?? plan.status}
+            </span>
+          </div>
+
+          <div className="flex flex-wrap gap-x-4 gap-y-2 font-body text-[12px] text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <Stethoscope className="h-3.5 w-3.5" />
+              {ATTENDANCE_TYPE_LABELS[plan.attendanceType] ?? plan.attendanceType}
+            </span>
+            {plan.workplace ? (
+              <span className="flex items-center gap-1.5">
+                <MapPin className="h-3.5 w-3.5" />
+                {plan.workplace.name}
+              </span>
+            ) : null}
+            <span className="flex items-center gap-1.5">
+              <CircleDollarSign className="h-3.5 w-3.5" />
+              {PRICING_MODEL_LABELS[plan.pricingModel] ?? plan.pricingModel}
+              {plan.pricingModel === 'PER_SESSION' && money(plan.sessionPrice)
+                ? ` (${money(plan.sessionPrice)})`
+                : null}
+              {plan.pricingModel === 'PACKAGE' && money(plan.packageAmount)
+                ? ` (${money(plan.packageAmount)})`
+                : null}
+            </span>
+          </div>
+
+          {plan.pricingModel === 'PACKAGE' ? (
+            <p className="font-body text-[12.5px] font-semibold text-foreground">
+              {sessionCount} de {plan.totalSessions ?? 0} sessoes
+            </p>
+          ) : (
+            <p className="font-body text-[12.5px] font-semibold text-foreground">
+              {sessionCount} {sessionCount === 1 ? 'sessao vinculada' : 'sessoes vinculadas'}
+            </p>
+          )}
+
+          {specialtyText ? (
+            <p className="font-body text-[12.5px] text-muted-foreground">{specialtyText}</p>
+          ) : null}
+
+          {plan.notes ? (
+            <p className="max-w-[680px] font-body text-[13px] leading-relaxed text-muted-foreground">
+              {plan.notes}
+            </p>
+          ) : null}
+        </div>
+
+        {showActions ? (
+          <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+            <Link
+              href={`/pacientes/${patientId}/planos/${plan.id}/editar`}
+              className="flex h-9 items-center gap-1.5 rounded-xl border border-border px-3 font-body text-[12px] font-semibold text-foreground transition-colors hover:border-primary/40 hover:bg-primary-soft"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              Editar
+            </Link>
+
+            {plan.status === 'ACTIVE' ? (
+              <button
+                type="button"
+                disabled={isPending || busyAction === 'pause'}
+                onClick={() => mutate('pause')}
+                className="flex h-9 items-center gap-1.5 rounded-xl border border-border px-3 font-body text-[12px] font-semibold text-foreground transition-colors hover:bg-muted disabled:opacity-60"
+              >
+                <Pause className="h-3.5 w-3.5" />
+                Pausar
+              </button>
+            ) : null}
+
+            {plan.status === 'PAUSED' ? (
+              <button
+                type="button"
+                disabled={isPending || busyAction === 'resume'}
+                onClick={() => mutate('resume')}
+                className="flex h-9 items-center gap-1.5 rounded-xl border border-border px-3 font-body text-[12px] font-semibold text-foreground transition-colors hover:bg-muted disabled:opacity-60"
+              >
+                <Play className="h-3.5 w-3.5" />
+                Retomar
+              </button>
+            ) : null}
+
+            {plan.status !== 'COMPLETED' && plan.status !== 'CANCELED' ? (
+              <button
+                type="button"
+                disabled={isPending || busyAction === 'complete'}
+                onClick={() => mutate('complete')}
+                className="flex h-9 items-center gap-1.5 rounded-xl bg-primary px-3 font-body text-[12px] font-semibold text-primary-foreground transition-colors hover:bg-primary-hover disabled:opacity-60"
+              >
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Concluir
+              </button>
+            ) : null}
+
+            {plan.status !== 'CANCELED' ? (
+              <button
+                type="button"
+                disabled={isPending || busyAction === 'cancel'}
+                onClick={() => mutate('cancel')}
+                className="flex h-9 items-center gap-1.5 rounded-xl bg-danger-soft px-3 font-body text-[12px] font-semibold text-danger transition-colors hover:bg-danger-soft/80 disabled:opacity-60"
+              >
+                <XCircle className="h-3.5 w-3.5" />
+                Cancelar
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </article>
+  )
+}

--- a/src/components/treatment-plans/TreatmentPlanForm.tsx
+++ b/src/components/treatment-plans/TreatmentPlanForm.tsx
@@ -1,0 +1,458 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { CalendarDays, CircleDollarSign } from 'lucide-react'
+import { DateTimePicker } from '@/components/ui/datetime-picker'
+import { ThemedSelect } from '@/components/ui/themed-select'
+import { cn } from '@/lib/utils'
+import {
+  ATTENDANCE_TYPE_LABELS,
+  PRICING_MODEL_LABELS,
+  SPECIALTY_LABELS,
+  THERAPY_AREA_LABELS,
+} from '@/lib/clinical-labels'
+
+type AttendanceType = 'CLINIC' | 'HOME_CARE' | 'HOSPITAL' | 'CORPORATE' | 'ONLINE'
+type PricingModel = 'PER_SESSION' | 'PACKAGE'
+
+interface WorkplaceSummary {
+  id: string
+  name: string
+  defaultAttendanceType: AttendanceType
+}
+
+interface TreatmentPlanFormData {
+  workplaceId: string
+  area: string
+  specialties: string[]
+  attendanceType: AttendanceType
+  pricingModel: PricingModel
+  sessionPrice: string
+  totalSessions: string
+  packageAmount: string
+  startsAt: string
+  endsAt: string
+  notes: string
+}
+
+export interface TreatmentPlanFormInitialValues {
+  id: string
+  workplaceId: string
+  area: string
+  specialties: string[]
+  attendanceType: AttendanceType
+  pricingModel: PricingModel
+  sessionPrice?: unknown
+  totalSessions?: number | null
+  packageAmount?: unknown
+  startsAt?: Date | string | null
+  endsAt?: Date | string | null
+  notes?: string | null
+}
+
+interface TreatmentPlanFormProps {
+  patientId: string
+  mode?: 'create' | 'edit'
+  initialValues?: TreatmentPlanFormInitialValues
+}
+
+const AREA_OPTIONS = Object.entries(THERAPY_AREA_LABELS).map(([value, label]) => ({
+  value,
+  label,
+}))
+
+const ATTENDANCE_OPTIONS = Object.entries(ATTENDANCE_TYPE_LABELS).map(([value, label]) => ({
+  value,
+  label,
+}))
+
+const PRICING_OPTIONS = Object.entries(PRICING_MODEL_LABELS).map(([value, label]) => ({
+  value,
+  label,
+}))
+
+const SPECIALTY_OPTIONS = Object.entries(SPECIALTY_LABELS).map(([value, label]) => ({
+  value,
+  label,
+}))
+
+const inputClass = cn(
+  'w-full rounded-xl border border-border bg-input px-3.5 py-2.5',
+  'font-body text-[14px] text-foreground placeholder:text-muted-foreground',
+  'focus:border-primary focus:outline-none focus:ring-2 focus:ring-ring',
+  'transition-colors duration-[180ms]'
+)
+
+function formatDateValue(value?: Date | string | null) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toISOString().slice(0, 10)
+}
+
+function numberString(value: unknown) {
+  if (value === null || value === undefined) return ''
+  return String(value)
+}
+
+function buildInitialValues(initialValues?: TreatmentPlanFormInitialValues): TreatmentPlanFormData {
+  if (initialValues) {
+    return {
+      workplaceId: initialValues.workplaceId,
+      area: initialValues.area,
+      specialties: initialValues.specialties ?? [],
+      attendanceType: initialValues.attendanceType,
+      pricingModel: initialValues.pricingModel,
+      sessionPrice: numberString(initialValues.sessionPrice),
+      totalSessions: numberString(initialValues.totalSessions),
+      packageAmount: numberString(initialValues.packageAmount),
+      startsAt: formatDateValue(initialValues.startsAt),
+      endsAt: formatDateValue(initialValues.endsAt),
+      notes: initialValues.notes ?? '',
+    }
+  }
+
+  return {
+    workplaceId: '',
+    area: 'ORTOPEDICA',
+    specialties: [],
+    attendanceType: 'CLINIC',
+    pricingModel: 'PER_SESSION',
+    sessionPrice: '',
+    totalSessions: '',
+    packageAmount: '',
+    startsAt: '',
+    endsAt: '',
+    notes: '',
+  }
+}
+
+function Field({
+  label,
+  error,
+  children,
+}: {
+  label: string
+  error?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="font-body text-[12px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+        {label}
+      </label>
+      {children}
+      {error ? <p className="font-body text-[12px] text-danger">{error}</p> : null}
+    </div>
+  )
+}
+
+export function TreatmentPlanForm({
+  patientId,
+  mode = 'create',
+  initialValues,
+}: TreatmentPlanFormProps) {
+  const router = useRouter()
+  const isEdit = mode === 'edit' && Boolean(initialValues)
+  const [form, setForm] = useState<TreatmentPlanFormData>(() => buildInitialValues(initialValues))
+  const [workplaces, setWorkplaces] = useState<WorkplaceSummary[]>([])
+  const [errors, setErrors] = useState<Partial<Record<keyof TreatmentPlanFormData, string>>>({})
+  const [serverError, setServerError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/workplaces')
+      .then((response) => response.json())
+      .then((data) => {
+        const list: WorkplaceSummary[] = data.workplaces ?? []
+        setWorkplaces(list)
+
+        if (!isEdit && list.length > 0) {
+          const first = list[0]
+          setForm((previous) => ({
+            ...previous,
+            workplaceId: previous.workplaceId || first.id,
+            attendanceType: previous.attendanceType || first.defaultAttendanceType,
+          }))
+        }
+      })
+      .catch(() => undefined)
+  }, [isEdit])
+
+  function set<K extends keyof TreatmentPlanFormData>(key: K, value: TreatmentPlanFormData[K]) {
+    setForm((previous) => ({ ...previous, [key]: value }))
+    setErrors((previous) => ({ ...previous, [key]: undefined }))
+  }
+
+  function toggleSpecialty(value: string) {
+    setForm((previous) => ({
+      ...previous,
+      specialties: previous.specialties.includes(value)
+        ? previous.specialties.filter((item) => item !== value)
+        : [...previous.specialties, value],
+    }))
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setServerError('')
+    setIsLoading(true)
+
+    const body = {
+      workplaceId: form.workplaceId,
+      area: form.area,
+      specialties: form.specialties,
+      attendanceType: form.attendanceType,
+      pricingModel: form.pricingModel,
+      sessionPrice: form.sessionPrice ? Number(form.sessionPrice) : undefined,
+      totalSessions: form.totalSessions ? Number(form.totalSessions) : undefined,
+      packageAmount: form.packageAmount ? Number(form.packageAmount) : undefined,
+      startsAt: form.startsAt || undefined,
+      endsAt: form.endsAt || undefined,
+      notes: form.notes,
+    }
+
+    try {
+      const url = isEdit
+        ? `/api/treatment-plans/${initialValues!.id}`
+        : `/api/patients/${patientId}/treatment-plans`
+      const response = await fetch(url, {
+        method: isEdit ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const data = await response.json().catch(() => ({}))
+
+      if (!response.ok) {
+        if (data.errors) {
+          const fieldErrors: typeof errors = {}
+          for (const [key, value] of Object.entries(data.errors)) {
+            fieldErrors[key as keyof TreatmentPlanFormData] = (value as string[])[0]
+          }
+          setErrors(fieldErrors)
+        } else {
+          setServerError(data.message ?? 'Erro ao salvar plano')
+        }
+        return
+      }
+
+      router.push(`/pacientes/${patientId}`)
+      router.refresh()
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const submitLabel = isLoading ? 'Salvando...' : isEdit ? 'Salvar alteracoes' : 'Criar plano'
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 sm:space-y-8">
+      {serverError ? (
+        <div className="rounded-xl border border-danger/20 bg-danger-soft px-4 py-3 font-body text-[13px] text-danger">
+          {serverError}
+        </div>
+      ) : null}
+
+      <section className="space-y-5 rounded-[18px] border border-border bg-card p-5 sm:p-6">
+        <div>
+          <h2 className="font-display text-[18px] font-bold text-foreground">Base do tratamento</h2>
+          <p className="mt-1 font-body text-[13px] text-muted-foreground">
+            Defina area, especialidades, local e modalidade principal.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Field label="Area *" error={errors.area}>
+            <ThemedSelect
+              value={form.area}
+              onChange={(next) => set('area', next)}
+              options={AREA_OPTIONS}
+              ariaLabel="Area terapeutica"
+            />
+          </Field>
+
+          <Field label="Local *" error={errors.workplaceId}>
+            <ThemedSelect
+              value={form.workplaceId}
+              onChange={(next) => {
+                const selected = workplaces.find((workplace) => workplace.id === next)
+                set('workplaceId', next)
+                if (selected) set('attendanceType', selected.defaultAttendanceType)
+              }}
+              options={[
+                { value: '', label: 'Selecionar local' },
+                ...workplaces.map((workplace) => ({ value: workplace.id, label: workplace.name })),
+              ]}
+              ariaLabel="Local de trabalho"
+            />
+          </Field>
+
+          <Field label="Modalidade *" error={errors.attendanceType}>
+            <ThemedSelect
+              value={form.attendanceType}
+              onChange={(next) => set('attendanceType', next as AttendanceType)}
+              options={ATTENDANCE_OPTIONS}
+              ariaLabel="Modalidade"
+            />
+          </Field>
+
+          <Field label="Cobranca *" error={errors.pricingModel}>
+            <ThemedSelect
+              value={form.pricingModel}
+              onChange={(next) => set('pricingModel', next as PricingModel)}
+              options={PRICING_OPTIONS}
+              ariaLabel="Modelo de cobranca"
+            />
+          </Field>
+        </div>
+
+        <div className="space-y-2">
+          <p className="font-body text-[12px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+            Especialidades
+          </p>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            {SPECIALTY_OPTIONS.map((option) => {
+              const checked = form.specialties.includes(option.value)
+              return (
+                <label
+                  key={option.value}
+                  className={cn(
+                    'flex cursor-pointer items-center gap-2 rounded-xl border px-3 py-2 font-body text-[12.5px] font-semibold transition-colors',
+                    checked
+                      ? 'border-primary bg-primary-soft text-primary-soft-fg'
+                      : 'border-border bg-background text-muted-foreground hover:bg-muted'
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleSpecialty(option.value)}
+                    className="h-4 w-4 accent-primary"
+                  />
+                  {option.label}
+                </label>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-5 rounded-[18px] border border-border bg-card p-5 sm:p-6">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary-soft text-primary">
+            <CircleDollarSign className="h-4 w-4" />
+          </div>
+          <div>
+            <h2 className="font-display text-[18px] font-bold text-foreground">
+              Condicao comercial
+            </h2>
+            <p className="mt-1 font-body text-[13px] text-muted-foreground">
+              Valores ficam prontos para a fase financeira, sem gerar pagamentos ainda.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {form.pricingModel === 'PER_SESSION' ? (
+            <Field label="Valor por sessao" error={errors.sessionPrice}>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                className={inputClass}
+                value={form.sessionPrice}
+                onChange={(event) => set('sessionPrice', event.target.value)}
+                placeholder="0,00"
+              />
+            </Field>
+          ) : (
+            <>
+              <Field label="Total de sessoes *" error={errors.totalSessions}>
+                <input
+                  type="number"
+                  min="1"
+                  step="1"
+                  className={inputClass}
+                  value={form.totalSessions}
+                  onChange={(event) => set('totalSessions', event.target.value)}
+                  placeholder="10"
+                />
+              </Field>
+
+              <Field label="Valor do pacote" error={errors.packageAmount}>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  className={inputClass}
+                  value={form.packageAmount}
+                  onChange={(event) => set('packageAmount', event.target.value)}
+                  placeholder="0,00"
+                />
+              </Field>
+            </>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-5 rounded-[18px] border border-border bg-card p-5 sm:p-6">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary-soft text-primary">
+            <CalendarDays className="h-4 w-4" />
+          </div>
+          <div>
+            <h2 className="font-display text-[18px] font-bold text-foreground">Periodo</h2>
+            <p className="mt-1 font-body text-[13px] text-muted-foreground">
+              Opcional para delimitar ciclos terapeuticos ou pacotes.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Field label="Inicio" error={errors.startsAt}>
+            <DateTimePicker
+              mode="date"
+              value={form.startsAt}
+              onChange={(next) => set('startsAt', next)}
+            />
+          </Field>
+
+          <Field label="Fim" error={errors.endsAt}>
+            <DateTimePicker
+              mode="date"
+              value={form.endsAt}
+              onChange={(next) => set('endsAt', next)}
+            />
+          </Field>
+        </div>
+
+        <Field label="Notas" error={errors.notes}>
+          <textarea
+            className={cn(inputClass, 'min-h-[96px] resize-y')}
+            value={form.notes}
+            onChange={(event) => set('notes', event.target.value)}
+            placeholder="Objetivos, restricoes e combinados do tratamento..."
+          />
+        </Field>
+      </section>
+
+      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-end">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="w-full rounded-xl px-5 py-2.5 font-body text-[13px] font-semibold text-muted-foreground transition-colors duration-[180ms] hover:bg-muted hover:text-foreground sm:w-auto"
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full rounded-xl bg-primary px-6 py-2.5 font-body text-[13px] font-semibold text-primary-foreground shadow-glow transition-colors duration-[180ms] hover:bg-primary-hover disabled:opacity-50 sm:w-auto"
+        >
+          {submitLabel}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/lib/clinical-labels.ts
+++ b/src/lib/clinical-labels.ts
@@ -1,0 +1,60 @@
+export const THERAPY_AREA_LABELS: Record<string, string> = {
+  ORTOPEDICA: 'Ortopedica',
+  NEUROLOGICA: 'Neurologica',
+  CARDIORESPIRATORIA: 'Cardiorrespiratoria',
+  ESTETICA: 'Estetica',
+  ESPORTIVA: 'Esportiva',
+  PELVICA: 'Pelvica',
+  PEDIATRICA: 'Pediatrica',
+  GERIATRICA: 'Geriatrica',
+  PREVENTIVA: 'Preventiva',
+  OUTRA: 'Outra',
+}
+
+export const SPECIALTY_LABELS: Record<string, string> = {
+  PILATES: 'Pilates',
+  RPG: 'RPG',
+  ACUPUNTURA: 'Acupuntura',
+  LIBERACAO_MIOFASCIAL: 'Liberacao miofascial',
+  VENTOSATERAPIA: 'Ventosaterapia',
+  DRY_NEEDLING: 'Dry needling',
+  TERAPIA_MANUAL: 'Terapia manual',
+  OUTRA: 'Outra',
+}
+
+export const ATTENDANCE_TYPE_LABELS: Record<string, string> = {
+  CLINIC: 'Clinica',
+  HOME_CARE: 'Domiciliar',
+  HOSPITAL: 'Hospital',
+  CORPORATE: 'Corporativo',
+  ONLINE: 'Online',
+}
+
+export const PLAN_STATUS_LABELS: Record<string, string> = {
+  ACTIVE: 'Ativo',
+  PAUSED: 'Pausado',
+  COMPLETED: 'Concluido',
+  CANCELED: 'Cancelado',
+}
+
+export const PRICING_MODEL_LABELS: Record<string, string> = {
+  PER_SESSION: 'Por sessao',
+  PACKAGE: 'Pacote',
+}
+
+export function formatSpecialties(specialties?: string[] | null) {
+  if (!specialties?.length) return ''
+  return specialties.map((specialty) => SPECIALTY_LABELS[specialty] ?? specialty).join(', ')
+}
+
+export function formatTreatmentPlanLabel(plan?: {
+  area?: string | null
+  specialties?: string[] | null
+}) {
+  if (!plan?.area) return 'Avulso'
+
+  const area = THERAPY_AREA_LABELS[plan.area] ?? plan.area
+  const specialties = formatSpecialties(plan.specialties)
+
+  return specialties ? `${area} (${specialties})` : area
+}

--- a/src/lib/pdf/render.ts
+++ b/src/lib/pdf/render.ts
@@ -18,7 +18,7 @@ interface Patient {
   name: string
   birthDate?: Date | string | null
   phone?: string | null
-  area: string
+  area?: string | null
   classification: string
   clinicalRecord?: {
     mainComplaint?: string | null

--- a/src/lib/pdf/templates/laudo.tsx
+++ b/src/lib/pdf/templates/laudo.tsx
@@ -1,13 +1,7 @@
 import React from 'react'
 import { Document, Page, View, Text } from '@react-pdf/renderer'
 import { baseStyles, COLORS } from '../styles'
-
-const AREA_LABELS: Record<string, string> = {
-  PILATES: 'Pilates',
-  MOTOR: 'Motora',
-  AESTHETIC: 'Estética',
-  HOME_CARE: 'Domiciliar',
-}
+import { THERAPY_AREA_LABELS } from '@/lib/clinical-labels'
 
 const CLASS_LABELS: Record<string, string> = {
   ELDERLY: 'Idoso',
@@ -29,7 +23,7 @@ interface LaudoData {
   patient: {
     name: string
     birthDate?: Date | string | null
-    area: string
+    area?: string | null
     classification: string
     phone?: string | null
     clinicalRecord?: {
@@ -80,7 +74,11 @@ export function LaudoTemplate({ data }: { data: LaudoData }) {
           )}
           <View style={baseStyles.row}>
             <Text style={baseStyles.label}>Área Terapêutica:</Text>
-            <Text style={baseStyles.value}>{AREA_LABELS[patient.area] ?? patient.area}</Text>
+            <Text style={baseStyles.value}>
+              {patient.area
+                ? (THERAPY_AREA_LABELS[patient.area] ?? patient.area)
+                : 'Sem plano vinculado'}
+            </Text>
           </View>
           <View style={baseStyles.row}>
             <Text style={baseStyles.label}>Classificação:</Text>
@@ -132,7 +130,9 @@ export function LaudoTemplate({ data }: { data: LaudoData }) {
         {/* Evolução */}
         {sessions.length > 0 && (
           <View style={baseStyles.section}>
-            <Text style={baseStyles.sectionTitle}>Evolução Clínica ({sessions.length} sessões)</Text>
+            <Text style={baseStyles.sectionTitle}>
+              Evolução Clínica ({sessions.length} sessões)
+            </Text>
             {sessions.map((s, i) => (
               <View key={i} style={baseStyles.sessionCard}>
                 <Text style={baseStyles.sessionDate}>Sessão — {formatDate(s.date)}</Text>
@@ -171,9 +171,7 @@ export function LaudoTemplate({ data }: { data: LaudoData }) {
           <View style={baseStyles.signatureBlock}>
             <Text style={baseStyles.signatureName}>{userName}</Text>
             <Text style={baseStyles.signatureRole}>Fisioterapeuta Responsável</Text>
-            <Text style={[baseStyles.signatureRole, { marginTop: 2 }]}>
-              {formatDate(emitedAt)}
-            </Text>
+            <Text style={[baseStyles.signatureRole, { marginTop: 2 }]}>{formatDate(emitedAt)}</Text>
           </View>
         </View>
       </Page>

--- a/src/lib/pdf/templates/relatorio.tsx
+++ b/src/lib/pdf/templates/relatorio.tsx
@@ -1,13 +1,7 @@
 import React from 'react'
 import { Document, Page, View, Text } from '@react-pdf/renderer'
 import { baseStyles } from '../styles'
-
-const AREA_LABELS: Record<string, string> = {
-  PILATES: 'Pilates',
-  MOTOR: 'Motora',
-  AESTHETIC: 'Estética',
-  HOME_CARE: 'Domiciliar',
-}
+import { THERAPY_AREA_LABELS } from '@/lib/clinical-labels'
 
 const STATUS_LABELS: Record<string, string> = {
   REALIZADO: 'Realizado',
@@ -29,7 +23,7 @@ interface RelatorioData {
   patient: {
     name: string
     birthDate?: Date | string | null
-    area: string
+    area?: string | null
   }
   period?: string
   sessions: Session[]
@@ -76,7 +70,11 @@ export function RelatorioTemplate({ data }: { data: RelatorioData }) {
           )}
           <View style={baseStyles.row}>
             <Text style={baseStyles.label}>Área Terapêutica:</Text>
-            <Text style={baseStyles.value}>{AREA_LABELS[patient.area] ?? patient.area}</Text>
+            <Text style={baseStyles.value}>
+              {patient.area
+                ? (THERAPY_AREA_LABELS[patient.area] ?? patient.area)
+                : 'Sem plano vinculado'}
+            </Text>
           </View>
           {period && (
             <View style={baseStyles.row}>
@@ -140,9 +138,7 @@ export function RelatorioTemplate({ data }: { data: RelatorioData }) {
           <View style={baseStyles.signatureBlock}>
             <Text style={baseStyles.signatureName}>{userName}</Text>
             <Text style={baseStyles.signatureRole}>Fisioterapeuta Responsável</Text>
-            <Text style={[baseStyles.signatureRole, { marginTop: 2 }]}>
-              {formatDate(emitedAt)}
-            </Text>
+            <Text style={[baseStyles.signatureRole, { marginTop: 2 }]}>{formatDate(emitedAt)}</Text>
           </View>
         </View>
       </Page>

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -13,6 +13,8 @@ const requiredDelegates = [
   'emailMessage',
   'calendarConnection',
   'calendarEventLink',
+  'workplace',
+  'treatmentPlan',
 ] as const
 
 function createPrismaClient() {

--- a/src/server/modules/calendar/infra/google-calendar.ts
+++ b/src/server/modules/calendar/infra/google-calendar.ts
@@ -3,6 +3,7 @@ import 'server-only'
 import { google } from 'googleapis'
 import type { OAuth2Client } from 'google-auth-library'
 import type { SessionWithPatient } from '@/server/modules/sessions/infra/session.repository'
+import { ATTENDANCE_TYPE_LABELS } from '@/lib/clinical-labels'
 
 const APP_TIME_ZONE = 'America/Sao_Paulo'
 
@@ -22,7 +23,7 @@ function getCalendarApi(auth: OAuth2Client) {
 }
 
 function buildLocation(session: SessionWithPatient) {
-  if (session.type !== 'HOME_CARE') return undefined
+  if (session.attendanceType !== 'HOME_CARE') return undefined
 
   return [session.patient.address, session.patient.neighborhood, session.patient.city]
     .filter(Boolean)
@@ -38,7 +39,7 @@ function buildEventResource(session: SessionWithPatient) {
     summary: `Atendimento - ${session.patient.name}`,
     description: [
       'Evento sincronizado pelo PhysioFlow.',
-      `Tipo: ${session.type === 'HOME_CARE' ? 'Domiciliar' : 'Presencial'}`,
+      `Modalidade: ${ATTENDANCE_TYPE_LABELS[session.attendanceType] ?? session.attendanceType}`,
       `Status: ${session.status}`,
     ].join('\n'),
     location,

--- a/src/server/modules/dashboard/application/get-metrics.ts
+++ b/src/server/modules/dashboard/application/get-metrics.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/lib/prisma'
-import type { SessionStatus, SessionType, TherapyArea } from '@/generated/prisma/client'
+import type { SessionStatus } from '@/generated/prisma/client'
 
 const APP_TZ = 'America/Sao_Paulo'
 
@@ -18,8 +18,8 @@ function shortDayLabel(dateKey: string): string {
 export interface RecentSessionItem {
   id: string
   patientName: string
-  type: SessionType
-  area: TherapyArea
+  attendanceType: string
+  treatmentPlan: { area: string; specialties: string[] } | null
   date: string
   status: SessionStatus
   isHomeCare: boolean
@@ -89,12 +89,13 @@ export async function getDashboardMetrics(userId: string): Promise<DashboardMetr
       orderBy: { date: 'desc' },
       take: 5,
       include: {
-        patient: { select: { name: true, area: true } },
+        patient: { select: { name: true } },
+        treatmentPlan: { select: { area: true, specialties: true } },
       },
     }),
   ])
 
-  const recentPatientIds = patientsWithRecentSession.map(s => s.patientId)
+  const recentPatientIds = patientsWithRecentSession.map((s) => s.patientId)
   const patientsWithoutReturn = await prisma.patient.count({
     where: {
       userId,
@@ -103,25 +104,25 @@ export async function getDashboardMetrics(userId: string): Promise<DashboardMetr
     },
   })
 
-  const countByDay = new Map<string, number>(weekDayKeys.map(k => [k, 0]))
+  const countByDay = new Map<string, number>(weekDayKeys.map((k) => [k, 0]))
   for (const s of weekSessionsRaw) {
     const k = dayKey(s.date)
     if (countByDay.has(k)) countByDay.set(k, (countByDay.get(k) ?? 0) + 1)
   }
 
-  const weeklySessions = weekDayKeys.map(k => ({
+  const weeklySessions = weekDayKeys.map((k) => ({
     day: shortDayLabel(k),
     count: countByDay.get(k) ?? 0,
   }))
 
-  const recentSessions: RecentSessionItem[] = recentSessionsRaw.map(s => ({
+  const recentSessions: RecentSessionItem[] = recentSessionsRaw.map((s) => ({
     id: s.id,
     patientName: s.patient.name,
-    type: s.type,
-    area: s.patient.area,
+    attendanceType: s.attendanceType,
+    treatmentPlan: s.treatmentPlan,
     date: s.date.toISOString(),
     status: s.status,
-    isHomeCare: s.type === 'HOME_CARE',
+    isHomeCare: s.attendanceType === 'HOME_CARE',
   }))
 
   return { activePatients, sessionsToday, patientsWithoutReturn, weeklySessions, recentSessions }

--- a/src/server/modules/documents/infra/document.repository.ts
+++ b/src/server/modules/documents/infra/document.repository.ts
@@ -6,8 +6,12 @@ const documentInclude = {
     select: {
       id: true,
       name: true,
-      area: true,
       classification: true,
+      treatmentPlans: {
+        where: { status: { in: ['ACTIVE', 'PAUSED'] } },
+        select: { id: true, area: true, specialties: true, status: true },
+        orderBy: { createdAt: 'desc' },
+      },
     },
   },
 } satisfies Prisma.DocumentInclude
@@ -79,6 +83,11 @@ export async function findDocumentForDownload(
       patient: {
         include: {
           clinicalRecord: true,
+          treatmentPlans: {
+            where: { status: { in: ['ACTIVE', 'PAUSED'] } },
+            select: { id: true, area: true, specialties: true, status: true },
+            orderBy: { createdAt: 'desc' },
+          },
           sessions: {
             where: {
               isActive: true,
@@ -91,6 +100,9 @@ export async function findDocumentForDownload(
                     },
                   }
                 : {}),
+            },
+            include: {
+              treatmentPlan: { select: { id: true, area: true, specialties: true } },
             },
             orderBy: { date: 'desc' },
             take: 20,

--- a/src/server/modules/email/application/send-document-email.ts
+++ b/src/server/modules/email/application/send-document-email.ts
@@ -31,6 +31,8 @@ export async function sendDocumentEmailUseCase(input: SendDocumentEmailInput) {
     throw new PatientEmailMissingError()
   }
 
+  const primaryPlan = document.patient.treatmentPlans?.[0] ?? null
+
   const pdf = await renderDocumentPDF({
     type: document.type,
     userName: document.user.name,
@@ -38,7 +40,7 @@ export async function sendDocumentEmailUseCase(input: SendDocumentEmailInput) {
       name: document.patient.name,
       birthDate: document.patient.birthDate,
       phone: document.patient.phone,
-      area: document.patient.area,
+      area: primaryPlan?.area,
       classification: document.patient.classification,
       clinicalRecord: document.patient.clinicalRecord,
     },

--- a/src/server/modules/email/application/send-session-reminder.ts
+++ b/src/server/modules/email/application/send-session-reminder.ts
@@ -8,6 +8,7 @@ import { sendEmailWithSettings } from '../infra/transporter'
 import { getSessionUseCase } from '@/server/modules/sessions/application/get-session'
 import { prisma } from '@/lib/prisma'
 import { formatDateLongPtBr, formatTimePtBr } from '@/lib/date'
+import { ATTENDANCE_TYPE_LABELS } from '@/lib/clinical-labels'
 
 interface SendSessionReminderInput {
   userId: string
@@ -42,18 +43,17 @@ export async function sendSessionReminderEmailUseCase(input: SendSessionReminder
 
   const dateLabel = formatDateLongPtBr(session.date)
   const timeLabel = formatTimePtBr(session.date)
-  const typeLabel = session.type === 'HOME_CARE' ? 'atendimento domiciliar' : 'atendimento presencial'
+  const modalityLabel = ATTENDANCE_TYPE_LABELS[session.attendanceType] ?? session.attendanceType
+  const typeLabel = `atendimento ${modalityLabel.toLowerCase()}`
 
   const addressLine =
-    session.type === 'HOME_CARE'
+    session.attendanceType === 'HOME_CARE'
       ? [patient.address, patient.neighborhood, patient.city].filter(Boolean).join(', ')
       : ''
 
   const subject = input.subject?.trim() || `Lembrete: ${typeLabel} em ${dateLabel}`
 
-  const introBody =
-    input.message?.trim() ||
-    `Passando para confirmar o seu ${typeLabel} agendado.`
+  const introBody = input.message?.trim() || `Passando para confirmar o seu ${typeLabel} agendado.`
 
   const lines: string[] = [
     `Olá, ${patient.name}!`,

--- a/src/server/modules/patients/application/create-patient.test.ts
+++ b/src/server/modules/patients/application/create-patient.test.ts
@@ -18,12 +18,11 @@ describe('createPatientUseCase', () => {
 
     const result = await createPatientUseCase('u1', {
       name: 'João Silva',
-      area: 'PILATES',
       classification: 'STANDARD',
     })
 
     expect(mockCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: 'u1', name: 'João Silva', area: 'PILATES' })
+      expect.objectContaining({ userId: 'u1', name: 'João Silva' })
     )
     expect(result).toBe(expected)
   })
@@ -33,7 +32,6 @@ describe('createPatientUseCase', () => {
 
     await createPatientUseCase('u1', {
       name: 'Maria',
-      area: 'MOTOR',
       classification: 'ELDERLY',
       birthDate: '1950-01-01',
     })
@@ -48,7 +46,6 @@ describe('createPatientUseCase', () => {
 
     await createPatientUseCase('u1', {
       name: 'Ana',
-      area: 'AESTHETIC',
       classification: 'STANDARD',
       email: '',
     })
@@ -61,7 +58,6 @@ describe('createPatientUseCase', () => {
 
     await createPatientUseCase('u1', {
       name: 'Lucas',
-      area: 'HOME_CARE',
       classification: 'POST_ACCIDENT',
       mainComplaint: 'Dor lombar persistente',
       allergies: 'Lactose',
@@ -83,7 +79,6 @@ describe('createPatientUseCase', () => {
     await expect(
       createPatientUseCase('u1', {
         name: 'Ana',
-        area: 'AESTHETIC',
         classification: 'STANDARD',
         email: 'ana@exemplo.com',
       })

--- a/src/server/modules/patients/application/create-patient.ts
+++ b/src/server/modules/patients/application/create-patient.ts
@@ -1,6 +1,6 @@
 import type { CreatePatientDTO } from '../http/patient.dto'
 import { parseDateOnly } from '@/lib/date'
-import type { PatientClassification, TherapyArea } from '@/generated/prisma/client'
+import type { PatientClassification } from '@/generated/prisma/client'
 import {
   hasClinicalRecordContent,
   normalizeClinicalRecordInput,
@@ -36,7 +36,6 @@ export async function createPatientUseCase(userId: string, dto: CreatePatientDTO
     phone: toNullableText(dto.phone),
     email: normalizedEmail,
     classification: dto.classification as PatientClassification,
-    area: dto.area as TherapyArea,
     notes: toNullableText(dto.notes),
     clinicalRecord: hasClinicalRecordContent(clinicalRecord) ? clinicalRecord : undefined,
   })

--- a/src/server/modules/patients/application/list-patients.test.ts
+++ b/src/server/modules/patients/application/list-patients.test.ts
@@ -22,25 +22,28 @@ describe('listPatientsUseCase', () => {
   it('não mescla pacientes de userId diferente', async () => {
     mockList.mockResolvedValue([])
 
-    await listPatientsUseCase('user-b', { area: 'PILATES' })
+    await listPatientsUseCase('user-b', { area: 'ORTOPEDICA' })
 
-    expect(mockList).toHaveBeenCalledWith('user-b', expect.objectContaining({ area: 'PILATES' }))
+    expect(mockList).toHaveBeenCalledWith('user-b', expect.objectContaining({ area: 'ORTOPEDICA' }))
     expect(mockList).not.toHaveBeenCalledWith('user-a', expect.anything())
   })
 
   it('passa filtros de area e classification para o repositório', async () => {
     mockList.mockResolvedValue([])
 
-    await listPatientsUseCase('u1', { area: 'MOTOR', classification: 'PCD', search: 'Rafael' })
+    await listPatientsUseCase('u1', { area: 'ESTETICA', classification: 'PCD', search: 'Rafael' })
 
     expect(mockList).toHaveBeenCalledWith(
       'u1',
-      expect.objectContaining({ area: 'MOTOR', classification: 'PCD', search: 'Rafael' }),
+      expect.objectContaining({ area: 'ESTETICA', classification: 'PCD', search: 'Rafael' })
     )
   })
 
   it('retorna a lista devolvida pelo repositório', async () => {
-    const patients = [{ id: 'p1', name: 'João' }, { id: 'p2', name: 'Maria' }]
+    const patients = [
+      { id: 'p1', name: 'João' },
+      { id: 'p2', name: 'Maria' },
+    ]
     mockList.mockResolvedValue(patients as never)
 
     const result = await listPatientsUseCase('u1')

--- a/src/server/modules/patients/application/update-patient.ts
+++ b/src/server/modules/patients/application/update-patient.ts
@@ -1,7 +1,7 @@
 import type { UpdatePatientDTO } from '../http/patient.dto'
 import { parseDateOnly } from '@/lib/date'
 import { PatientNotFoundError } from './get-patient'
-import type { PatientClassification, TherapyArea } from '@/generated/prisma/client'
+import type { PatientClassification } from '@/generated/prisma/client'
 import {
   hasClinicalRecordContent,
   normalizeClinicalRecordInput,
@@ -26,7 +26,6 @@ export async function updatePatientUseCase(id: string, userId: string, dto: Upda
     phone,
     notes,
     classification,
-    area,
   } = dto
 
   const normalizedEmail = toOptionalNullableEmail(email)
@@ -58,7 +57,6 @@ export async function updatePatientUseCase(id: string, userId: string, dto: Upda
       phone: toOptionalNullableText(phone),
       email: normalizedEmail,
       classification: classification as PatientClassification | undefined,
-      area: area as TherapyArea | undefined,
       notes: toOptionalNullableText(notes),
     },
     hasClinicalUpdates &&

--- a/src/server/modules/patients/domain/patient.ts
+++ b/src/server/modules/patients/domain/patient.ts
@@ -1,6 +1,6 @@
-import type { PatientClassification, TherapyArea } from '@/generated/prisma/client'
+import type { PatientClassification } from '@/generated/prisma/client'
 
-export type { PatientClassification, TherapyArea }
+export type { PatientClassification }
 
 type OptionalStringInput = string | null | undefined
 
@@ -12,7 +12,6 @@ export interface Patient {
   phone: string | null
   email: string | null
   classification: PatientClassification
-  area: TherapyArea
   notes: string | null
   isActive: boolean
   createdAt: Date

--- a/src/server/modules/patients/http/patient.dto.ts
+++ b/src/server/modules/patients/http/patient.dto.ts
@@ -14,13 +14,25 @@ const optionalText = z.string().trim().optional()
 
 const homeCarePriorityEnum = z.enum(['NORMAL', 'HIGH', 'URGENT'])
 
+const therapyAreaEnum = z.enum([
+  'ORTOPEDICA',
+  'NEUROLOGICA',
+  'CARDIORESPIRATORIA',
+  'ESTETICA',
+  'ESPORTIVA',
+  'PELVICA',
+  'PEDIATRICA',
+  'GERIATRICA',
+  'PREVENTIVA',
+  'OUTRA',
+])
+
 export const createPatientDTO = z.object({
   name: z.string().trim().min(2, 'Nome deve ter ao menos 2 caracteres'),
   birthDate: optionalDateString,
   phone: optionalText,
   email: optionalEmail,
   classification: z.enum(['ELDERLY', 'PCD', 'POST_ACCIDENT', 'STANDARD']).default('STANDARD'),
-  area: z.enum(['PILATES', 'MOTOR', 'AESTHETIC', 'HOME_CARE']),
   notes: optionalText,
   mainComplaint: optionalText,
   medicalHistory: optionalText,
@@ -39,7 +51,6 @@ export const updatePatientDTO = z.object({
   phone: optionalText,
   email: optionalEmail,
   classification: z.enum(['ELDERLY', 'PCD', 'POST_ACCIDENT', 'STANDARD']).optional(),
-  area: z.enum(['PILATES', 'MOTOR', 'AESTHETIC', 'HOME_CARE']).optional(),
   notes: optionalText,
   mainComplaint: optionalText,
   medicalHistory: optionalText,
@@ -53,7 +64,7 @@ export const updatePatientDTO = z.object({
 })
 
 export const listPatientsDTO = z.object({
-  area: z.enum(['PILATES', 'MOTOR', 'AESTHETIC', 'HOME_CARE']).optional(),
+  area: therapyAreaEnum.optional(),
   classification: z.enum(['ELDERLY', 'PCD', 'POST_ACCIDENT', 'STANDARD']).optional(),
   search: z.string().trim().optional(),
 })

--- a/src/server/modules/patients/infra/patient.repository.ts
+++ b/src/server/modules/patients/infra/patient.repository.ts
@@ -1,6 +1,27 @@
 import { prisma } from '@/lib/prisma'
-import type { PatientClassification, TherapyArea } from '@/generated/prisma/client'
+import type { PatientClassification, Prisma, TherapyArea } from '@/generated/prisma/client'
 import type { ClinicalRecordInput } from '../domain/patient'
+
+const patientInclude = {
+  clinicalRecord: true,
+  treatmentPlans: {
+    where: { status: { in: ['ACTIVE', 'PAUSED'] } },
+    select: {
+      id: true,
+      area: true,
+      specialties: true,
+      attendanceType: true,
+      pricingModel: true,
+      status: true,
+      totalSessions: true,
+      packageAmount: true,
+      sessionPrice: true,
+      workplace: { select: { id: true, name: true } },
+      _count: { select: { sessions: true } },
+    },
+    orderBy: [{ status: 'asc' }, { createdAt: 'desc' }],
+  },
+} satisfies Prisma.PatientInclude
 
 export interface PatientCreateInput {
   userId: string
@@ -9,7 +30,6 @@ export interface PatientCreateInput {
   phone?: string | null
   email?: string | null
   classification: PatientClassification
-  area: TherapyArea
   notes?: string | null
   clinicalRecord?: ClinicalRecordInput
 }
@@ -20,7 +40,6 @@ export interface PatientUpdateInput {
   phone?: string | null
   email?: string | null
   classification?: PatientClassification
-  area?: TherapyArea
   notes?: string | null
 }
 
@@ -40,7 +59,7 @@ export async function createPatient(data: PatientCreateInput) {
       ...patientData,
       ...(clinicalRecord ? { clinicalRecord: { create: clinicalRecord } } : {}),
     },
-    include: { clinicalRecord: true },
+    include: patientInclude,
   })
 }
 
@@ -49,11 +68,13 @@ export async function listPatients(userId: string, filters: ListFilters = {}) {
     where: {
       userId,
       isActive: true,
-      ...(filters.area ? { area: filters.area } : {}),
       ...(filters.classification ? { classification: filters.classification } : {}),
       ...(filters.search ? { name: { contains: filters.search, mode: 'insensitive' } } : {}),
+      ...(filters.area
+        ? { treatmentPlans: { some: { area: filters.area, status: 'ACTIVE' } } }
+        : {}),
     },
-    include: { clinicalRecord: true },
+    include: patientInclude,
     orderBy: { createdAt: 'desc' },
   })
 }
@@ -61,7 +82,7 @@ export async function listPatients(userId: string, filters: ListFilters = {}) {
 export async function findPatientById(id: string, userId: string) {
   return prisma.patient.findFirst({
     where: { id, userId, isActive: true },
-    include: { clinicalRecord: true },
+    include: patientInclude,
   })
 }
 
@@ -96,7 +117,7 @@ export async function updatePatient(
           }
         : {}),
     },
-    include: { clinicalRecord: true },
+    include: patientInclude,
   })
 }
 

--- a/src/server/modules/sessions/application/create-session.test.ts
+++ b/src/server/modules/sessions/application/create-session.test.ts
@@ -5,17 +5,25 @@ import { InvalidSessionScheduleError } from '../domain/session'
 import { createSessionUseCase } from './create-session'
 import { createSession } from '../infra/session.repository'
 import { syncSessionCalendarAfterMutation } from '@/server/modules/calendar/application/auto-sync-session-calendar'
+import { findDefaultWorkplace } from '@/server/modules/workplaces/infra/workplace.repository'
 
 vi.mock('@/server/modules/patients/infra/patient.repository')
 vi.mock('../infra/session.repository')
 vi.mock('@/server/modules/calendar/application/auto-sync-session-calendar')
+vi.mock('@/server/modules/workplaces/infra/workplace.repository')
+vi.mock('@/server/modules/treatment-plans/infra/treatment-plan.repository')
 
 const mockFindPatientById = vi.mocked(findPatientById)
 const mockCreateSession = vi.mocked(createSession)
 const mockSyncSessionCalendarAfterMutation = vi.mocked(syncSessionCalendarAfterMutation)
+const mockFindDefaultWorkplace = vi.mocked(findDefaultWorkplace)
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockFindDefaultWorkplace.mockResolvedValue({
+    id: 'wp-default',
+    defaultAttendanceType: 'CLINIC',
+  } as never)
 })
 
 describe('createSessionUseCase', () => {
@@ -29,7 +37,6 @@ describe('createSessionUseCase', () => {
       patientId: 'patient-1',
       date: futureDate,
       duration: 50,
-      type: 'PRESENTIAL',
       status: 'AGENDADO',
       subjective: ' Dor lombar ',
       objective: '',
@@ -42,8 +49,9 @@ describe('createSessionUseCase', () => {
         userId: 'user-1',
         patientId: 'patient-1',
         duration: 50,
-        type: 'PRESENTIAL',
         status: 'AGENDADO',
+        workplaceId: 'wp-default',
+        attendanceType: 'CLINIC',
         subjective: 'Dor lombar',
         objective: null,
         assessment: 'Boa evolução',
@@ -66,7 +74,6 @@ describe('createSessionUseCase', () => {
         patientId: 'patient-other',
         date: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
         duration: 60,
-        type: 'PRESENTIAL',
         status: 'AGENDADO',
       })
     ).rejects.toBeInstanceOf(PatientNotFoundError)
@@ -80,7 +87,6 @@ describe('createSessionUseCase', () => {
         patientId: 'patient-1',
         date: '2024-01-01T10:00:00.000Z',
         duration: 60,
-        type: 'PRESENTIAL',
         status: 'AGENDADO',
       })
     ).rejects.toBeInstanceOf(InvalidSessionScheduleError)

--- a/src/server/modules/sessions/application/create-session.ts
+++ b/src/server/modules/sessions/application/create-session.ts
@@ -1,7 +1,12 @@
-import type { AttendanceType, SessionStatus, SessionType } from '@/generated/prisma/client'
+import type { AttendanceType, SessionStatus } from '@/generated/prisma/client'
 import { PatientNotFoundError } from '@/server/modules/patients/application/get-patient'
 import { findPatientById } from '@/server/modules/patients/infra/patient.repository'
 import { findDefaultWorkplace } from '@/server/modules/workplaces/infra/workplace.repository'
+import { findTreatmentPlanById } from '@/server/modules/treatment-plans/infra/treatment-plan.repository'
+import {
+  TreatmentPlanInactiveError,
+  TreatmentPlanNotFoundError,
+} from '@/server/modules/treatment-plans/domain/treatment-plan'
 import type { CreateSessionDTO } from '../http/session.dto'
 import { createSession } from '../infra/session.repository'
 import { assertSessionSchedule, normalizeSessionSoapInput } from '../domain/session'
@@ -21,27 +26,43 @@ export async function createSessionUseCase(userId: string, dto: CreateSessionDTO
 
   let workplaceId = dto.workplaceId ?? null
   let attendanceType = (dto.attendanceType as AttendanceType | undefined) ?? null
+  let treatmentPlanId: string | null = null
+
+  if (dto.treatmentPlanId) {
+    const plan = await findTreatmentPlanById(dto.treatmentPlanId, userId)
+    if (!plan || plan.patientId !== dto.patientId) {
+      throw new TreatmentPlanNotFoundError()
+    }
+    if (plan.status === 'COMPLETED' || plan.status === 'CANCELED') {
+      throw new TreatmentPlanInactiveError()
+    }
+    treatmentPlanId = plan.id
+    if (!workplaceId) workplaceId = plan.workplaceId
+    if (!attendanceType) attendanceType = plan.attendanceType
+  }
 
   if (!workplaceId) {
     const defaultWorkplace = await findDefaultWorkplace(userId)
     if (defaultWorkplace) {
       workplaceId = defaultWorkplace.id
-      if (!attendanceType) {
-        attendanceType = defaultWorkplace.defaultAttendanceType
-      }
+      if (!attendanceType) attendanceType = defaultWorkplace.defaultAttendanceType
     }
   }
 
+  if (!workplaceId) {
+    throw new Error('Nenhum local de trabalho disponível para criar a sessão')
+  }
+
   if (!attendanceType) {
-    attendanceType = dto.type === 'HOME_CARE' ? 'HOME_CARE' : 'CLINIC'
+    attendanceType = 'CLINIC'
   }
 
   const createdSession = await createSession({
     userId,
     patientId: dto.patientId,
+    treatmentPlanId,
     date,
     duration: dto.duration,
-    type: dto.type as SessionType,
     status,
     workplaceId,
     attendanceType,

--- a/src/server/modules/sessions/application/list-sessions.test.ts
+++ b/src/server/modules/sessions/application/list-sessions.test.ts
@@ -25,7 +25,7 @@ describe('listSessionsUseCase', () => {
     await listSessionsUseCase('user-b', {
       patientId: 'patient-1',
       status: 'AGENDADO',
-      area: 'MOTOR',
+      area: 'ORTOPEDICA',
       from: '2026-04-24T10:00:00.000Z',
       page: 2,
       limit: 15,
@@ -37,7 +37,7 @@ describe('listSessionsUseCase', () => {
       expect.objectContaining({
         patientId: 'patient-1',
         status: 'AGENDADO',
-        area: 'MOTOR',
+        area: 'ORTOPEDICA',
         from: expect.any(Date),
         page: 2,
         limit: 15,

--- a/src/server/modules/sessions/application/list-sessions.ts
+++ b/src/server/modules/sessions/application/list-sessions.ts
@@ -1,4 +1,4 @@
-import type { SessionStatus, SessionType, TherapyArea } from '@/generated/prisma/client'
+import type { AttendanceType, SessionStatus, TherapyArea } from '@/generated/prisma/client'
 import type { ListSessionsDTO } from '../http/session.dto'
 import { listSessions } from '../infra/session.repository'
 
@@ -9,8 +9,9 @@ export interface ListSessionsUseCaseInput extends Partial<ListSessionsDTO> {
 export async function listSessionsUseCase(userId: string, filters: ListSessionsUseCaseInput = {}) {
   return listSessions(userId, {
     patientId: filters.patientId,
+    treatmentPlanId: filters.treatmentPlanId,
     status: filters.status as SessionStatus | undefined,
-    type: filters.type as SessionType | undefined,
+    attendanceType: filters.attendanceType as AttendanceType | undefined,
     area: filters.area as TherapyArea | undefined,
     from: filters.from ? new Date(filters.from) : undefined,
     to: filters.to ? new Date(filters.to) : undefined,

--- a/src/server/modules/sessions/application/update-session.ts
+++ b/src/server/modules/sessions/application/update-session.ts
@@ -1,4 +1,9 @@
-import type { AttendanceType, SessionStatus, SessionType } from '@/generated/prisma/client'
+import type { AttendanceType, SessionStatus } from '@/generated/prisma/client'
+import { findTreatmentPlanById } from '@/server/modules/treatment-plans/infra/treatment-plan.repository'
+import {
+  TreatmentPlanInactiveError,
+  TreatmentPlanNotFoundError,
+} from '@/server/modules/treatment-plans/domain/treatment-plan'
 import type { UpdateSessionDTO } from '../http/session.dto'
 import { normalizePartialSessionSoapInput, assertSessionSchedule } from '../domain/session'
 import { findSessionById, updateSession } from '../infra/session.repository'
@@ -17,13 +22,32 @@ export async function updateSessionUseCase(id: string, userId: string, dto: Upda
 
   assertSessionSchedule(nextDate, nextStatus)
 
+  let treatmentPlanId: string | null | undefined
+  let workplaceId = dto.workplaceId
+  let attendanceType = dto.attendanceType as AttendanceType | undefined
+
+  if (dto.treatmentPlanId === null || dto.treatmentPlanId === '') {
+    treatmentPlanId = null
+  } else if (typeof dto.treatmentPlanId === 'string') {
+    const plan = await findTreatmentPlanById(dto.treatmentPlanId, userId)
+    if (!plan || plan.patientId !== existing.patientId) {
+      throw new TreatmentPlanNotFoundError()
+    }
+    if (plan.status === 'COMPLETED' || plan.status === 'CANCELED') {
+      throw new TreatmentPlanInactiveError()
+    }
+    treatmentPlanId = plan.id
+    if (!workplaceId) workplaceId = plan.workplaceId
+    if (!attendanceType) attendanceType = plan.attendanceType
+  }
+
   const updatedSession = await updateSession(id, {
+    treatmentPlanId,
     date: dto.date ? nextDate : undefined,
     duration: dto.duration,
-    type: dto.type as SessionType | undefined,
     status: dto.status as SessionStatus | undefined,
-    workplaceId: dto.workplaceId,
-    attendanceType: dto.attendanceType as AttendanceType | undefined,
+    workplaceId,
+    attendanceType,
     ...normalizePartialSessionSoapInput({
       subjective: dto.subjective,
       objective: dto.objective,

--- a/src/server/modules/sessions/http/session.dto.ts
+++ b/src/server/modules/sessions/http/session.dto.ts
@@ -13,21 +13,33 @@ const optionalDateTimeString = z
 
 const optionalText = z.string().trim().optional()
 const optionalBoolean = z.coerce.boolean().optional()
+const attendanceTypeEnum = z.enum(['CLINIC', 'HOME_CARE', 'HOSPITAL', 'CORPORATE', 'ONLINE'])
+
+const therapyAreaEnum = z.enum([
+  'ORTOPEDICA',
+  'NEUROLOGICA',
+  'CARDIORESPIRATORIA',
+  'ESTETICA',
+  'ESPORTIVA',
+  'PELVICA',
+  'PEDIATRICA',
+  'GERIATRICA',
+  'PREVENTIVA',
+  'OUTRA',
+])
 
 export const createSessionDTO = z.object({
   patientId: z.string().trim().min(1, 'Paciente é obrigatório'),
+  treatmentPlanId: z.string().trim().optional(),
   date: requiredDateTimeString,
   duration: z.coerce
     .number()
     .int('Duração deve ser um número inteiro')
     .min(15, 'Duração mínima de 15 minutos')
     .max(240, 'Duração máxima de 240 minutos'),
-  type: z.enum(['PRESENTIAL', 'HOME_CARE']).default('PRESENTIAL'),
   status: z.enum(['AGENDADO', 'REALIZADO', 'CANCELADO']).default('AGENDADO'),
   workplaceId: z.string().trim().optional(),
-  attendanceType: z
-    .enum(['CLINIC', 'HOME_CARE', 'HOSPITAL', 'CORPORATE', 'ONLINE'])
-    .optional(),
+  attendanceType: attendanceTypeEnum.optional(),
   subjective: optionalText,
   objective: optionalText,
   assessment: optionalText,
@@ -36,6 +48,7 @@ export const createSessionDTO = z.object({
 })
 
 export const updateSessionDTO = z.object({
+  treatmentPlanId: z.string().trim().nullish(),
   date: optionalDateTimeString,
   duration: z.coerce
     .number()
@@ -43,12 +56,9 @@ export const updateSessionDTO = z.object({
     .min(15, 'Duração mínima de 15 minutos')
     .max(240, 'Duração máxima de 240 minutos')
     .optional(),
-  type: z.enum(['PRESENTIAL', 'HOME_CARE']).optional(),
   status: z.enum(['AGENDADO', 'REALIZADO', 'CANCELADO']).optional(),
   workplaceId: z.string().trim().optional(),
-  attendanceType: z
-    .enum(['CLINIC', 'HOME_CARE', 'HOSPITAL', 'CORPORATE', 'ONLINE'])
-    .optional(),
+  attendanceType: attendanceTypeEnum.optional(),
   subjective: optionalText,
   objective: optionalText,
   assessment: optionalText,
@@ -58,9 +68,10 @@ export const updateSessionDTO = z.object({
 
 export const listSessionsDTO = z.object({
   patientId: z.string().trim().optional(),
+  treatmentPlanId: z.string().trim().optional(),
   status: z.enum(['AGENDADO', 'REALIZADO', 'CANCELADO']).optional(),
-  type: z.enum(['PRESENTIAL', 'HOME_CARE']).optional(),
-  area: z.enum(['PILATES', 'MOTOR', 'AESTHETIC', 'HOME_CARE']).optional(),
+  attendanceType: attendanceTypeEnum.optional(),
+  area: therapyAreaEnum.optional(),
   from: optionalDateTimeString,
   to: optionalDateTimeString,
   page: z.coerce.number().int().min(1).default(1),

--- a/src/server/modules/sessions/infra/session.repository.ts
+++ b/src/server/modules/sessions/infra/session.repository.ts
@@ -1,18 +1,11 @@
 import { prisma } from '@/lib/prisma'
-import type {
-  AttendanceType,
-  Prisma,
-  SessionStatus,
-  SessionType,
-  TherapyArea,
-} from '@/generated/prisma/client'
+import type { AttendanceType, Prisma, SessionStatus, TherapyArea } from '@/generated/prisma/client'
 
 const sessionInclude = {
   patient: {
     select: {
       id: true,
       name: true,
-      area: true,
       classification: true,
       homeCarePriority: true,
       address: true,
@@ -23,6 +16,16 @@ const sessionInclude = {
   },
   workplace: {
     select: { id: true, name: true },
+  },
+  treatmentPlan: {
+    select: {
+      id: true,
+      area: true,
+      specialties: true,
+      attendanceType: true,
+      status: true,
+      pricingModel: true,
+    },
   },
   calendarEventLinks: {
     where: { provider: 'GOOGLE' },
@@ -43,12 +46,12 @@ export type SessionWithPatient = Prisma.SessionGetPayload<{ include: typeof sess
 export interface SessionCreateInput {
   userId: string
   patientId: string
+  treatmentPlanId?: string | null
   date: Date
   duration: number
-  type: SessionType
   status: SessionStatus
-  workplaceId?: string | null
-  attendanceType?: AttendanceType | null
+  workplaceId: string
+  attendanceType: AttendanceType
   subjective?: string | null
   objective?: string | null
   assessment?: string | null
@@ -56,12 +59,12 @@ export interface SessionCreateInput {
 }
 
 export interface SessionUpdateInput {
+  treatmentPlanId?: string | null
   date?: Date
   duration?: number
-  type?: SessionType
   status?: SessionStatus
-  workplaceId?: string | null
-  attendanceType?: AttendanceType | null
+  workplaceId?: string
+  attendanceType?: AttendanceType
   subjective?: string | null
   objective?: string | null
   assessment?: string | null
@@ -70,8 +73,9 @@ export interface SessionUpdateInput {
 
 export interface ListSessionFilters {
   patientId?: string
+  treatmentPlanId?: string
   status?: SessionStatus
-  type?: SessionType
+  attendanceType?: AttendanceType
   area?: TherapyArea
   from?: Date
   to?: Date
@@ -92,9 +96,10 @@ export async function listSessions(userId: string, filters: ListSessionFilters =
     userId,
     isActive: true,
     ...(filters.patientId ? { patientId: filters.patientId } : {}),
+    ...(filters.treatmentPlanId ? { treatmentPlanId: filters.treatmentPlanId } : {}),
     ...(filters.status ? { status: filters.status } : {}),
-    ...(filters.type ? { type: filters.type } : {}),
-    ...(filters.area ? { patient: { area: filters.area } } : {}),
+    ...(filters.attendanceType ? { attendanceType: filters.attendanceType } : {}),
+    ...(filters.area ? { treatmentPlan: { area: filters.area } } : {}),
     ...(filters.from || filters.to
       ? {
           date: {

--- a/src/server/modules/treatment-plans/application/change-status.test.ts
+++ b/src/server/modules/treatment-plans/application/change-status.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TreatmentPlanNotFoundError } from '../domain/treatment-plan'
+import { findTreatmentPlanById, setTreatmentPlanStatus } from '../infra/treatment-plan.repository'
+import {
+  cancelTreatmentPlanUseCase,
+  completeTreatmentPlanUseCase,
+  pauseTreatmentPlanUseCase,
+  resumeTreatmentPlanUseCase,
+} from './change-status'
+
+vi.mock('../infra/treatment-plan.repository')
+
+const mockFindTreatmentPlanById = vi.mocked(findTreatmentPlanById)
+const mockSetTreatmentPlanStatus = vi.mocked(setTreatmentPlanStatus)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('changeTreatmentPlanStatus use cases', () => {
+  it('altera status preservando filtro por userId', async () => {
+    mockFindTreatmentPlanById.mockResolvedValue({ id: 'plan-1', userId: 'user-1' } as never)
+    mockSetTreatmentPlanStatus.mockResolvedValue({ id: 'plan-1', status: 'PAUSED' } as never)
+
+    await pauseTreatmentPlanUseCase('plan-1', 'user-1')
+
+    expect(mockFindTreatmentPlanById).toHaveBeenCalledWith('plan-1', 'user-1')
+    expect(mockSetTreatmentPlanStatus).toHaveBeenCalledWith('plan-1', 'PAUSED')
+  })
+
+  it('expoe acoes de retomar, concluir e cancelar', async () => {
+    mockFindTreatmentPlanById.mockResolvedValue({ id: 'plan-1', userId: 'user-1' } as never)
+    mockSetTreatmentPlanStatus.mockResolvedValue({ id: 'plan-1' } as never)
+
+    await resumeTreatmentPlanUseCase('plan-1', 'user-1')
+    await completeTreatmentPlanUseCase('plan-1', 'user-1')
+    await cancelTreatmentPlanUseCase('plan-1', 'user-1')
+
+    expect(mockSetTreatmentPlanStatus).toHaveBeenNthCalledWith(1, 'plan-1', 'ACTIVE')
+    expect(mockSetTreatmentPlanStatus).toHaveBeenNthCalledWith(2, 'plan-1', 'COMPLETED')
+    expect(mockSetTreatmentPlanStatus).toHaveBeenNthCalledWith(3, 'plan-1', 'CANCELED')
+  })
+
+  it('rejeita plano inexistente ou de outro usuário', async () => {
+    mockFindTreatmentPlanById.mockResolvedValue(null)
+
+    await expect(pauseTreatmentPlanUseCase('plan-other', 'user-1')).rejects.toBeInstanceOf(
+      TreatmentPlanNotFoundError
+    )
+
+    expect(mockSetTreatmentPlanStatus).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/modules/treatment-plans/application/change-status.ts
+++ b/src/server/modules/treatment-plans/application/change-status.ts
@@ -1,0 +1,21 @@
+import type { PlanStatus } from '@/generated/prisma/client'
+import { TreatmentPlanNotFoundError } from '../domain/treatment-plan'
+import { findTreatmentPlanById, setTreatmentPlanStatus } from '../infra/treatment-plan.repository'
+
+async function changeStatus(id: string, userId: string, status: PlanStatus) {
+  const existing = await findTreatmentPlanById(id, userId)
+  if (!existing) throw new TreatmentPlanNotFoundError()
+  return setTreatmentPlanStatus(id, status)
+}
+
+export const pauseTreatmentPlanUseCase = (id: string, userId: string) =>
+  changeStatus(id, userId, 'PAUSED')
+
+export const resumeTreatmentPlanUseCase = (id: string, userId: string) =>
+  changeStatus(id, userId, 'ACTIVE')
+
+export const completeTreatmentPlanUseCase = (id: string, userId: string) =>
+  changeStatus(id, userId, 'COMPLETED')
+
+export const cancelTreatmentPlanUseCase = (id: string, userId: string) =>
+  changeStatus(id, userId, 'CANCELED')

--- a/src/server/modules/treatment-plans/application/create-treatment-plan.test.ts
+++ b/src/server/modules/treatment-plans/application/create-treatment-plan.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PatientNotFoundError } from '@/server/modules/patients/application/get-patient'
+import { findPatientById } from '@/server/modules/patients/infra/patient.repository'
+import { findWorkplaceById } from '@/server/modules/workplaces/infra/workplace.repository'
+import { WorkplaceForPlanNotFoundError } from '../domain/treatment-plan'
+import { createTreatmentPlan } from '../infra/treatment-plan.repository'
+import { createTreatmentPlanUseCase } from './create-treatment-plan'
+
+vi.mock('@/server/modules/patients/infra/patient.repository')
+vi.mock('@/server/modules/workplaces/infra/workplace.repository')
+vi.mock('../infra/treatment-plan.repository')
+
+const mockFindPatientById = vi.mocked(findPatientById)
+const mockFindWorkplaceById = vi.mocked(findWorkplaceById)
+const mockCreateTreatmentPlan = vi.mocked(createTreatmentPlan)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createTreatmentPlanUseCase', () => {
+  it('cria plano para paciente e local do usuário', async () => {
+    mockFindPatientById.mockResolvedValue({ id: 'patient-1', userId: 'user-1' } as never)
+    mockFindWorkplaceById.mockResolvedValue({ id: 'workplace-1', userId: 'user-1' } as never)
+    mockCreateTreatmentPlan.mockResolvedValue({ id: 'plan-1' } as never)
+
+    const result = await createTreatmentPlanUseCase('user-1', 'patient-1', {
+      workplaceId: 'workplace-1',
+      area: 'ORTOPEDICA',
+      specialties: ['PILATES'],
+      attendanceType: 'CLINIC',
+      pricingModel: 'PACKAGE',
+      totalSessions: 10,
+      packageAmount: 1500,
+      startsAt: '2026-04-25',
+      notes: ' Plano inicial ',
+    })
+
+    expect(result).toEqual({ id: 'plan-1' })
+    expect(mockCreateTreatmentPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        patientId: 'patient-1',
+        workplaceId: 'workplace-1',
+        area: 'ORTOPEDICA',
+        specialties: ['PILATES'],
+        attendanceType: 'CLINIC',
+        pricingModel: 'PACKAGE',
+        totalSessions: 10,
+        packageAmount: 1500,
+        notes: 'Plano inicial',
+      })
+    )
+  })
+
+  it('rejeita paciente de outro usuário', async () => {
+    mockFindPatientById.mockResolvedValue(null)
+
+    await expect(
+      createTreatmentPlanUseCase('user-1', 'patient-other', {
+        workplaceId: 'workplace-1',
+        area: 'ORTOPEDICA',
+        specialties: [],
+        attendanceType: 'CLINIC',
+        pricingModel: 'PER_SESSION',
+      })
+    ).rejects.toBeInstanceOf(PatientNotFoundError)
+
+    expect(mockCreateTreatmentPlan).not.toHaveBeenCalled()
+  })
+
+  it('rejeita local de trabalho de outro usuário', async () => {
+    mockFindPatientById.mockResolvedValue({ id: 'patient-1', userId: 'user-1' } as never)
+    mockFindWorkplaceById.mockResolvedValue(null)
+
+    await expect(
+      createTreatmentPlanUseCase('user-1', 'patient-1', {
+        workplaceId: 'workplace-other',
+        area: 'ESTETICA',
+        specialties: [],
+        attendanceType: 'HOME_CARE',
+        pricingModel: 'PER_SESSION',
+      })
+    ).rejects.toBeInstanceOf(WorkplaceForPlanNotFoundError)
+
+    expect(mockCreateTreatmentPlan).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/modules/treatment-plans/application/create-treatment-plan.ts
+++ b/src/server/modules/treatment-plans/application/create-treatment-plan.ts
@@ -1,0 +1,49 @@
+import type {
+  AttendanceType,
+  PricingModel,
+  Specialty,
+  TherapyArea,
+} from '@/generated/prisma/client'
+import { PatientNotFoundError } from '@/server/modules/patients/application/get-patient'
+import { findPatientById } from '@/server/modules/patients/infra/patient.repository'
+import { findWorkplaceById } from '@/server/modules/workplaces/infra/workplace.repository'
+import { WorkplaceForPlanNotFoundError } from '../domain/treatment-plan'
+import type { CreateTreatmentPlanDTO } from '../http/treatment-plan.dto'
+import { createTreatmentPlan } from '../infra/treatment-plan.repository'
+
+function parseDate(value?: string) {
+  if (!value) return null
+  return new Date(value)
+}
+
+export async function createTreatmentPlanUseCase(
+  userId: string,
+  patientId: string,
+  dto: CreateTreatmentPlanDTO
+) {
+  const patient = await findPatientById(patientId, userId)
+  if (!patient) {
+    throw new PatientNotFoundError('Paciente não encontrado')
+  }
+
+  const workplace = await findWorkplaceById(dto.workplaceId, userId)
+  if (!workplace) {
+    throw new WorkplaceForPlanNotFoundError()
+  }
+
+  return createTreatmentPlan({
+    userId,
+    patientId,
+    workplaceId: dto.workplaceId,
+    area: dto.area as TherapyArea,
+    specialties: dto.specialties as Specialty[],
+    attendanceType: dto.attendanceType as AttendanceType,
+    pricingModel: dto.pricingModel as PricingModel,
+    sessionPrice: dto.sessionPrice ?? null,
+    totalSessions: dto.totalSessions ?? null,
+    packageAmount: dto.packageAmount ?? null,
+    startsAt: parseDate(dto.startsAt),
+    endsAt: parseDate(dto.endsAt),
+    notes: dto.notes?.trim() || null,
+  })
+}

--- a/src/server/modules/treatment-plans/application/get-treatment-plan.ts
+++ b/src/server/modules/treatment-plans/application/get-treatment-plan.ts
@@ -1,0 +1,10 @@
+import { TreatmentPlanNotFoundError } from '../domain/treatment-plan'
+import { findTreatmentPlanById } from '../infra/treatment-plan.repository'
+
+export { TreatmentPlanNotFoundError }
+
+export async function getTreatmentPlanUseCase(id: string, userId: string) {
+  const plan = await findTreatmentPlanById(id, userId)
+  if (!plan) throw new TreatmentPlanNotFoundError()
+  return plan
+}

--- a/src/server/modules/treatment-plans/application/list-treatment-plans.ts
+++ b/src/server/modules/treatment-plans/application/list-treatment-plans.ts
@@ -1,0 +1,16 @@
+import type { PlanStatus } from '@/generated/prisma/client'
+import type { ListTreatmentPlansDTO } from '../http/treatment-plan.dto'
+import { listPatientTreatmentPlans } from '../infra/treatment-plan.repository'
+
+export async function listPatientTreatmentPlansUseCase(
+  userId: string,
+  patientId: string,
+  filters: ListTreatmentPlansDTO = {}
+) {
+  const plans = await listPatientTreatmentPlans(
+    userId,
+    patientId,
+    filters.status as PlanStatus | undefined
+  )
+  return { plans }
+}

--- a/src/server/modules/treatment-plans/application/update-treatment-plan.ts
+++ b/src/server/modules/treatment-plans/application/update-treatment-plan.ts
@@ -1,0 +1,46 @@
+import type {
+  AttendanceType,
+  PlanStatus,
+  PricingModel,
+  Specialty,
+  TherapyArea,
+} from '@/generated/prisma/client'
+import { findWorkplaceById } from '@/server/modules/workplaces/infra/workplace.repository'
+import { TreatmentPlanNotFoundError, WorkplaceForPlanNotFoundError } from '../domain/treatment-plan'
+import type { UpdateTreatmentPlanDTO } from '../http/treatment-plan.dto'
+import { findTreatmentPlanById, updateTreatmentPlan } from '../infra/treatment-plan.repository'
+
+function parseDate(value?: string) {
+  if (value === undefined) return undefined
+  if (value === '') return null
+  return new Date(value)
+}
+
+export async function updateTreatmentPlanUseCase(
+  id: string,
+  userId: string,
+  dto: UpdateTreatmentPlanDTO
+) {
+  const existing = await findTreatmentPlanById(id, userId)
+  if (!existing) throw new TreatmentPlanNotFoundError()
+
+  if (dto.workplaceId && dto.workplaceId !== existing.workplaceId) {
+    const workplace = await findWorkplaceById(dto.workplaceId, userId)
+    if (!workplace) throw new WorkplaceForPlanNotFoundError()
+  }
+
+  return updateTreatmentPlan(id, {
+    workplaceId: dto.workplaceId,
+    area: dto.area as TherapyArea | undefined,
+    specialties: dto.specialties as Specialty[] | undefined,
+    attendanceType: dto.attendanceType as AttendanceType | undefined,
+    pricingModel: dto.pricingModel as PricingModel | undefined,
+    status: dto.status as PlanStatus | undefined,
+    sessionPrice: dto.sessionPrice,
+    totalSessions: dto.totalSessions,
+    packageAmount: dto.packageAmount,
+    startsAt: parseDate(dto.startsAt),
+    endsAt: parseDate(dto.endsAt),
+    notes: dto.notes === undefined ? undefined : dto.notes?.trim() || null,
+  })
+}

--- a/src/server/modules/treatment-plans/domain/treatment-plan.ts
+++ b/src/server/modules/treatment-plans/domain/treatment-plan.ts
@@ -1,0 +1,20 @@
+export class TreatmentPlanNotFoundError extends Error {
+  constructor(message = 'Plano de tratamento não encontrado') {
+    super(message)
+    this.name = 'TreatmentPlanNotFoundError'
+  }
+}
+
+export class TreatmentPlanInactiveError extends Error {
+  constructor(message = 'Plano de tratamento não está ativo') {
+    super(message)
+    this.name = 'TreatmentPlanInactiveError'
+  }
+}
+
+export class WorkplaceForPlanNotFoundError extends Error {
+  constructor(message = 'Local de trabalho não encontrado') {
+    super(message)
+    this.name = 'WorkplaceForPlanNotFoundError'
+  }
+}

--- a/src/server/modules/treatment-plans/http/treatment-plan.dto.ts
+++ b/src/server/modules/treatment-plans/http/treatment-plan.dto.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod'
+
+const therapyAreaEnum = z.enum([
+  'ORTOPEDICA',
+  'NEUROLOGICA',
+  'CARDIORESPIRATORIA',
+  'ESTETICA',
+  'ESPORTIVA',
+  'PELVICA',
+  'PEDIATRICA',
+  'GERIATRICA',
+  'PREVENTIVA',
+  'OUTRA',
+])
+
+const specialtyEnum = z.enum([
+  'PILATES',
+  'RPG',
+  'ACUPUNTURA',
+  'LIBERACAO_MIOFASCIAL',
+  'VENTOSATERAPIA',
+  'DRY_NEEDLING',
+  'TERAPIA_MANUAL',
+  'OUTRA',
+])
+
+const attendanceTypeEnum = z.enum(['CLINIC', 'HOME_CARE', 'HOSPITAL', 'CORPORATE', 'ONLINE'])
+const pricingModelEnum = z.enum(['PER_SESSION', 'PACKAGE'])
+const planStatusEnum = z.enum(['ACTIVE', 'COMPLETED', 'CANCELED', 'PAUSED'])
+
+const optionalDateString = z
+  .string()
+  .trim()
+  .refine((value) => value === '' || !Number.isNaN(Date.parse(value)), 'Data inválida')
+  .optional()
+
+const optionalText = z.string().trim().optional()
+
+export const createTreatmentPlanDTO = z
+  .object({
+    workplaceId: z.string().trim().min(1, 'Local de trabalho é obrigatório'),
+    area: therapyAreaEnum,
+    specialties: z.array(specialtyEnum).default([]),
+    attendanceType: attendanceTypeEnum,
+    pricingModel: pricingModelEnum.default('PER_SESSION'),
+    sessionPrice: z.coerce.number().nonnegative().optional(),
+    totalSessions: z.coerce.number().int().positive().optional(),
+    packageAmount: z.coerce.number().nonnegative().optional(),
+    startsAt: optionalDateString,
+    endsAt: optionalDateString,
+    notes: optionalText,
+  })
+  .refine(
+    (data) => data.pricingModel !== 'PACKAGE' || (data.totalSessions && data.totalSessions > 0),
+    { message: 'Pacote requer total de sessões', path: ['totalSessions'] }
+  )
+
+export const updateTreatmentPlanDTO = z.object({
+  workplaceId: z.string().trim().min(1).optional(),
+  area: therapyAreaEnum.optional(),
+  specialties: z.array(specialtyEnum).optional(),
+  attendanceType: attendanceTypeEnum.optional(),
+  pricingModel: pricingModelEnum.optional(),
+  status: planStatusEnum.optional(),
+  sessionPrice: z.coerce.number().nonnegative().optional(),
+  totalSessions: z.coerce.number().int().positive().optional(),
+  packageAmount: z.coerce.number().nonnegative().optional(),
+  startsAt: optionalDateString,
+  endsAt: optionalDateString,
+  notes: optionalText,
+})
+
+export const listTreatmentPlansDTO = z.object({
+  status: planStatusEnum.optional(),
+})
+
+export type CreateTreatmentPlanDTO = z.infer<typeof createTreatmentPlanDTO>
+export type UpdateTreatmentPlanDTO = z.infer<typeof updateTreatmentPlanDTO>
+export type ListTreatmentPlansDTO = z.infer<typeof listTreatmentPlansDTO>

--- a/src/server/modules/treatment-plans/infra/treatment-plan.repository.ts
+++ b/src/server/modules/treatment-plans/infra/treatment-plan.repository.ts
@@ -1,0 +1,92 @@
+import { prisma } from '@/lib/prisma'
+import type {
+  AttendanceType,
+  PlanStatus,
+  PricingModel,
+  Prisma,
+  Specialty,
+  TherapyArea,
+} from '@/generated/prisma/client'
+
+const treatmentPlanInclude = {
+  workplace: { select: { id: true, name: true } },
+  patient: { select: { id: true, name: true } },
+  _count: { select: { sessions: true } },
+} satisfies Prisma.TreatmentPlanInclude
+
+export type TreatmentPlanWithRelations = Prisma.TreatmentPlanGetPayload<{
+  include: typeof treatmentPlanInclude
+}>
+
+export interface TreatmentPlanCreateInput {
+  userId: string
+  patientId: string
+  workplaceId: string
+  area: TherapyArea
+  specialties: Specialty[]
+  attendanceType: AttendanceType
+  pricingModel: PricingModel
+  sessionPrice?: number | null
+  totalSessions?: number | null
+  packageAmount?: number | null
+  startsAt?: Date | null
+  endsAt?: Date | null
+  notes?: string | null
+}
+
+export interface TreatmentPlanUpdateInput {
+  workplaceId?: string
+  area?: TherapyArea
+  specialties?: Specialty[]
+  attendanceType?: AttendanceType
+  pricingModel?: PricingModel
+  status?: PlanStatus
+  sessionPrice?: number | null
+  totalSessions?: number | null
+  packageAmount?: number | null
+  startsAt?: Date | null
+  endsAt?: Date | null
+  notes?: string | null
+}
+
+export async function createTreatmentPlan(data: TreatmentPlanCreateInput) {
+  return prisma.treatmentPlan.create({
+    data,
+    include: treatmentPlanInclude,
+  })
+}
+
+export async function findTreatmentPlanById(id: string, userId: string) {
+  return prisma.treatmentPlan.findFirst({
+    where: { id, userId },
+    include: treatmentPlanInclude,
+  })
+}
+
+export async function listPatientTreatmentPlans(
+  userId: string,
+  patientId: string,
+  status?: PlanStatus
+) {
+  return prisma.treatmentPlan.findMany({
+    where: { userId, patientId, ...(status ? { status } : {}) },
+    include: treatmentPlanInclude,
+    orderBy: [{ status: 'asc' }, { createdAt: 'desc' }],
+  })
+}
+
+export async function updateTreatmentPlan(id: string, data: TreatmentPlanUpdateInput) {
+  return prisma.treatmentPlan.update({
+    where: { id },
+    data,
+    include: treatmentPlanInclude,
+  })
+}
+
+export async function setTreatmentPlanStatus(id: string, status: PlanStatus) {
+  return prisma.treatmentPlan.update({
+    where: { id },
+    data: { status },
+    include: treatmentPlanInclude,
+  })
+}


### PR DESCRIPTION
## Resumo

Implementa a Phase 15 de Plano de Tratamento e multi-modalidade clínica.

- Cria `TreatmentPlan`, novos enums (`Specialty`, `PricingModel`, `PlanStatus`) e expande `TherapyArea`.
- Adiciona migrations com backfill de planos legados, vínculo de sessões e remoção dos campos legados `Patient.area` e `Session.type`.
- Implementa módulo `treatment-plans` com DTOs, use cases, repository, endpoints REST e testes unitários.
- Atualiza ficha do paciente, formulários de plano, `SessionForm`, `SessionCard`, agenda, dashboard, documentos, e-mails e Google Calendar para o novo modelo.
- Atualiza seed e documentação viva (`README`, `.docs/CONTEXT.md`, `.docs/CHANGELOG.md`, task da Phase 15).

Closes #6

## Validação

- `npx prisma validate`
- `npm run lint`
- `npm run test` (11 arquivos, 33 testes)
- `npm run build`
- `git diff --check`

## Observação

`npm run format:check` global ainda falha por arquivos antigos fora deste escopo, incluindo `physioflow-design-system/project/colors_and_type.css` com erro de sintaxe CSS. Os arquivos tocados foram formatados com Prettier e `prisma format`.