### PR TITLE
feat: phase 17 — dashboard financeiro

### DIFF
--- a/.docs/CHANGELOG.md
+++ b/.docs/CHANGELOG.md
@@ -9,6 +9,29 @@ e o projeto segue [Conventional Commits](https://www.conventionalcommits.org/) e
 
 ### Added
 
+- **Phase 17 — Dashboard Financeiro**
+  - Módulo `finance` com `getFinanceSummaryUseCase` (apenas leitura): agrega
+    recebido (`Payment.status` PAID/PARTIAL no período), previsto por sessões
+    (`Session.AGENDADO` com `expectedFee` e `paymentStatus` PENDING/PARTIAL) e por
+    parcelas de pacote (`Payment.PENDING` com `dueAt` no período); calcula delta
+    contra o período anterior, série temporal por dia/semana/mês, breakdowns por
+    `Workplace` e por `TherapyArea`, e top 50 pendências ordenadas por `dueAt`
+  - Endpoint `GET /api/finance/summary?from&to&granularity&workplaceIds&areas`
+    (Decimal serializado como string para precisão)
+  - Página `/financeiro` (server component) com `FinancePeriodPicker` (presets
+    hoje / 7d / 30d / mês atual / mês anterior + granularidade dia/semana/mês),
+    três `FinanceSummaryCard` (recebido, previsto com quebra sessão+pacote,
+    período anterior), `FinanceTimelineChart` SVG nativo (linha recebido vs
+    previsto), `FinanceBreakdownPanel` por local e por área, e
+    `PendingPaymentsTable` com ação "Marcar pago" abrindo `RegisterPaymentModal`
+  - Mini-cards "Caixa do mês" e "A receber este mês" no `/dashboard` linkando
+    para `/financeiro?preset=month`
+  - Sidebar com novo link "Financeiro" (ícone `CircleDollarSign`)
+  - Proxy autenticado cobrindo `/financeiro/**`
+  - Testes unitários do `getFinanceSummaryUseCase` (cenário com dados e cenário
+    vazio)
+  - **PhysioFlow v2** (multi-modalidade + financeiro) entregue ao final desta fase
+
 - **Phase 16 — Pagamentos**
   - Enums `PaymentMethod` (`PIX`, `CASH`, `CREDIT_CARD`, `DEBIT_CARD`, `BANK_TRANSFER`,
     `INSURANCE`, `OTHER`) e `PaymentStatus` (`PAID`, `PENDING`, `PARTIAL`, `REFUNDED`)

--- a/.docs/CONTEXT.md
+++ b/.docs/CONTEXT.md
@@ -4,6 +4,20 @@
 
 ## Fase Atual
 
+**Phase 17 — Dashboard Financeiro concluída**
+Módulo `finance` com `getFinanceSummaryUseCase` que agrega recebido (Payment PAID/PARTIAL),
+previsto (Session AGENDADO com `expectedFee` + Payment PENDING com `dueAt`), série temporal
+por dia/semana/mês, breakdowns por workplace e por área e top 50 pendências ordenadas por
+`dueAt`. Endpoint `GET /api/finance/summary?from&to&granularity&workplaceIds&areas`.
+Página `/financeiro` com `FinancePeriodPicker` (presets hoje/7d/30d/mês/mês anterior),
+3 cards de KPI (recebido, previsto, período anterior), `FinanceTimelineChart` SVG (linha
+recebido vs previsto), `FinanceBreakdownPanel` por local e por área e `PendingPaymentsTable`
+com ação "Marcar pago" abrindo `RegisterPaymentModal` da Phase 16. Mini-cards "Caixa do
+mês" e "A receber este mês" no `/dashboard` linkando para `/financeiro?preset=month`.
+Sidebar com link "Financeiro" (ícone `CircleDollarSign`). Multi-tenant em todas as queries.
+Cálculo on-demand sem persistir agregados; serialização Decimal → string para evitar erro
+de Server→Client Component. PhysioFlow v2 (multi-modalidade + financeiro) entregue.
+
 **Phase 16 — Pagamentos concluída**
 Modelo `Payment` criado com vínculo XOR a `Session` ou `TreatmentPlan` (constraint SQL),
 enums `PaymentMethod` e `PaymentStatus`, e snapshot `Session.expectedFee` + cache
@@ -85,9 +99,9 @@ Campos de endereço e prioridade no modelo `Patient`, seção de logística na f
 
 ## Próximo Passo Planejado
 
-**Phase 17 — Dashboard Financeiro** — [task file](tasks/phase-17-finance-dashboard.md)
-Consumir `Payment` e `Session.expectedFee` para agregar recebido vs previsto, série
-temporal, quebras por local/área e lista de pendências.
+Ciclo "Multi-modalidade + Financeiro" concluído (phases 14–17). Próximas extensões
+opcionais: comissão líquida, exportação CSV/PDF, lembrete automático de parcela,
+templates de plano e especialidades cadastráveis. Validar com usuários quais doem mais.
 
 Pendências operacionais:
 
@@ -112,7 +126,6 @@ Pendências operacionais:
 
 ### Tasks planejadas
 
-- `.docs/tasks/phase-17-finance-dashboard.md` — Dashboard financeiro (recebido vs previsto)
 - `.docs/decisions/ADR-005-multi-modalidade-financeiro.md` — Decisão proposta para
   multi-modalidade clínica e acompanhamento financeiro
 
@@ -121,6 +134,7 @@ Pendências operacionais:
 - `.docs/tasks/phase-14-workplaces.md` — Locais de trabalho (`Workplace`, `AttendanceType`, CRUD + UI)
 - `.docs/tasks/phase-15-treatment-plans.md` — Plano de tratamento e multi-modalidade
 - `.docs/tasks/phase-16-payments.md` — Pagamentos e cobrança (avulso e pacote)
+- `.docs/tasks/phase-17-finance-dashboard.md` — Dashboard financeiro (recebido vs previsto)
 - `.docs/tasks/phase-9-ux-polish.md` — Polimentos visuais e de microinteração
 - `.docs/tasks/phase-10-clinical-agenda-flow.md` — Edição SOAP e visualização mensal da agenda
 - `.docs/tasks/phase-11-email-notifications.md` — Gmail App Password e envios
@@ -250,6 +264,7 @@ Módulo `calendar` segue o mesmo padrão em `src/server/modules/calendar/`
 Módulo `workplaces` segue o mesmo padrão em `src/server/modules/workplaces/`
 Módulo `treatment-plans` segue o mesmo padrão em `src/server/modules/treatment-plans/`
 Módulo `payments` segue o mesmo padrão em `src/server/modules/payments/`
+Módulo `finance` em `src/server/modules/finance/` (apenas leitura — agrega Payment + Session)
 
 ## Pendências Conhecidas
 

--- a/.docs/tasks/phase-17-finance-dashboard.md
+++ b/.docs/tasks/phase-17-finance-dashboard.md
@@ -4,7 +4,7 @@
 
 - [ ] Todo
 - [ ] In Progress
-- [ ] Done
+- [x] Done
 
 ## Contexto
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ PhysioFlow centraliza toda a operação clínica em uma interface única — do 
   modalidade, local e pacote/avulso preparatório para o financeiro
 - **Pagamentos** — Registro de cobranças avulsas e pacotes com método, status e snapshot
   `expectedFee` por sessão; saldo do plano e do paciente, modal de registro
-
-### Em desenvolvimento (ciclo Multi-modalidade + Financeiro)
-
-- **Dashboard Financeiro** — Recebido vs previsto por dia/semana/mês e quebra por
-  local/área
+- **Dashboard Financeiro** — Página `/financeiro` com cards de recebido/previsto, gráfico
+  série temporal, quebras por local e área, tabela de pendências com "marcar pago" em
+  um clique e mini-cards no dashboard principal
 
 ---
 
@@ -202,18 +200,19 @@ Após o seed:
 - Phase 16 — Pagamentos (modelo `Payment` com vínculo XOR sessão/plano, snapshot
   `Session.expectedFee`, cache `paymentStatus`, CRUD REST de pagamentos, saldo do plano,
   saldo do paciente, badges/modal e seção financeira na ficha)
+- Phase 17 — Dashboard Financeiro (`/financeiro` com cards de recebido/previsto,
+  gráfico série temporal, breakdowns por local/área e tabela de pendências; mini-cards
+  no `/dashboard`; **PhysioFlow v2** entregue)
 
-### 🗺️ Planejado — Ciclo "Multi-modalidade + Financeiro"
+### 🗺️ Próximas extensões (opcionais)
 
-> Decisão arquitetural: [ADR-005](.docs/decisions/ADR-005-multi-modalidade-financeiro.md)
-
-- **Phase 17 — Dashboard Financeiro** (recebido vs previsto, série temporal,
-  breakdowns por local/área, lista de pendências)
+- Phase 18 — Comissão líquida usando `Workplace.defaultCommissionPct`
+- Phase 19 — Exportação CSV/PDF do dashboard financeiro
+- Phase 20 — Lembrete automático de parcela a vencer (e-mail / WhatsApp)
+- Phase 21 — Templates de plano de tratamento
+- Phase 22 — Especialidades cadastráveis pelo usuário (migrar enum → tabela)
 
 ### ➡️ Próximo Passo
 
-Iniciar **Phase 17**: dashboard financeiro consumindo `Payment` e `Session.expectedFee`
-com agregações por período, local e área.
-
-Ainda pendente do ciclo anterior: configurar as variáveis de e-mail/Google na Vercel e
-validar os fluxos reais de envio e sincronização.
+Validar com usuários reais quais extensões priorizar. Pendências operacionais: configurar
+as variáveis de e-mail/Google na Vercel e validar os fluxos reais de envio e sincronização.

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,6 +1,8 @@
-import { Users, CalendarCheck, TrendingUp } from 'lucide-react'
+import Link from 'next/link'
+import { Users, CalendarCheck, TrendingUp, CircleDollarSign, Clock3 } from 'lucide-react'
 import { getSession } from '@/lib/session'
 import { getDashboardMetrics } from '@/server/modules/dashboard/application/get-metrics'
+import { getFinanceSummaryUseCase } from '@/server/modules/finance/application/get-finance-summary'
 import { KpiCard } from '@/components/dashboard/KpiCard'
 import { WeeklyChart } from '@/components/dashboard/WeeklyChart'
 import { QuickActions } from '@/components/dashboard/QuickActions'
@@ -18,9 +20,27 @@ function formatGreetingDate(date: Date): string {
   }).format(date)
 }
 
+function moneyShort(value: string) {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    maximumFractionDigits: 0,
+  }).format(Number(value))
+}
+
 export default async function DashboardPage() {
   const session = await getSession()
   const metrics = await getDashboardMetrics(session.userId!)
+
+  const today = new Date()
+  const monthFrom = new Date(today.getFullYear(), today.getMonth(), 1)
+  const monthTo = new Date(today.getFullYear(), today.getMonth() + 1, 0, 23, 59, 59, 999)
+  const finance = await getFinanceSummaryUseCase({
+    userId: session.userId!,
+    from: monthFrom,
+    to: monthTo,
+    granularity: 'day',
+  })
 
   const firstName = session.name?.split(' ')[0] ?? 'bem-vindo'
   const dateLabel = formatGreetingDate(new Date())
@@ -58,6 +78,44 @@ export default async function DashboardPage() {
           variant="accent"
           urgent={metrics.patientsWithoutReturn > 0}
         />
+      </div>
+
+      {/* Mini-cards financeiros */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Link
+          href="/financeiro?preset=month"
+          className="group rounded-[18px] border border-border bg-card p-4 shadow-sm transition-colors hover:border-primary/40 hover:bg-primary-soft/40"
+        >
+          <div className="flex items-center justify-between">
+            <p className="font-body text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Caixa do mês
+            </p>
+            <CircleDollarSign className="h-4 w-4 text-primary" />
+          </div>
+          <p className="mt-2 font-display text-[24px] font-bold text-foreground">
+            {moneyShort(finance.totalReceived)}
+          </p>
+          <p className="mt-1 font-body text-[12px] text-muted-foreground group-hover:text-primary-soft-fg">
+            recebido até hoje
+          </p>
+        </Link>
+        <Link
+          href="/financeiro?preset=month"
+          className="group rounded-[18px] border border-border bg-card p-4 shadow-sm transition-colors hover:border-primary/40 hover:bg-primary-soft/40"
+        >
+          <div className="flex items-center justify-between">
+            <p className="font-body text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              A receber este mês
+            </p>
+            <Clock3 className="h-4 w-4 text-primary" />
+          </div>
+          <p className="mt-2 font-display text-[24px] font-bold text-foreground">
+            {moneyShort(finance.totalForecast)}
+          </p>
+          <p className="mt-1 font-body text-[12px] text-muted-foreground group-hover:text-primary-soft-fg">
+            previsto em sessões e parcelas
+          </p>
+        </Link>
       </div>
 
       {/* Gráfico + Ações rápidas */}

--- a/src/app/(app)/financeiro/page.tsx
+++ b/src/app/(app)/financeiro/page.tsx
@@ -1,0 +1,162 @@
+import { CircleDollarSign } from 'lucide-react'
+import { getSession } from '@/lib/session'
+import { getFinanceSummaryUseCase } from '@/server/modules/finance/application/get-finance-summary'
+import type { Granularity } from '@/server/modules/finance/domain/finance'
+import { FinanceSummaryCard } from '@/components/finance/FinanceSummaryCard'
+import { FinanceTimelineChart } from '@/components/finance/FinanceTimelineChart'
+import { FinanceBreakdownPanel } from '@/components/finance/FinanceBreakdownPanel'
+import { PendingPaymentsTable } from '@/components/finance/PendingPaymentsTable'
+import { FinancePeriodPicker } from '@/components/finance/FinancePeriodPicker'
+
+const AREA_LABELS: Record<string, string> = {
+  ORTOPEDICA: 'Ortopédica',
+  NEUROLOGICA: 'Neurológica',
+  CARDIORESPIRATORIA: 'Cardiorrespiratória',
+  ESTETICA: 'Estética',
+  ESPORTIVA: 'Esportiva',
+  PELVICA: 'Pélvica',
+  PEDIATRICA: 'Pediátrica',
+  GERIATRICA: 'Geriátrica',
+  PREVENTIVA: 'Preventiva',
+  OUTRA: 'Outra',
+}
+
+function money(value: string) {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  }).format(Number(value))
+}
+
+function startOfDay(value: Date) {
+  const next = new Date(value.getTime())
+  next.setHours(0, 0, 0, 0)
+  return next
+}
+
+function endOfDay(value: Date) {
+  const next = new Date(value.getTime())
+  next.setHours(23, 59, 59, 999)
+  return next
+}
+
+function resolvePreset(preset: string): { from: Date; to: Date; label: string } {
+  const today = new Date()
+  if (preset === 'today') {
+    return { from: startOfDay(today), to: endOfDay(today), label: 'Hoje' }
+  }
+  if (preset === '7d') {
+    const from = new Date(today)
+    from.setDate(today.getDate() - 6)
+    return { from: startOfDay(from), to: endOfDay(today), label: 'Últimos 7 dias' }
+  }
+  if (preset === 'last-month') {
+    const ref = new Date(today.getFullYear(), today.getMonth() - 1, 1)
+    const from = new Date(ref.getFullYear(), ref.getMonth(), 1)
+    const to = new Date(ref.getFullYear(), ref.getMonth() + 1, 0, 23, 59, 59, 999)
+    return { from, to, label: 'Mês anterior' }
+  }
+  if (preset === 'month') {
+    const from = new Date(today.getFullYear(), today.getMonth(), 1)
+    return { from, to: endOfDay(today), label: 'Este mês' }
+  }
+  // default 30d
+  const from = new Date(today)
+  from.setDate(today.getDate() - 29)
+  return { from: startOfDay(from), to: endOfDay(today), label: 'Últimos 30 dias' }
+}
+
+interface FinanceiroPageProps {
+  searchParams: Promise<{ preset?: string; granularity?: string }>
+}
+
+export default async function FinanceiroPage({ searchParams }: FinanceiroPageProps) {
+  const params = await searchParams
+  const preset = params.preset ?? '30d'
+  const granularityRaw = params.granularity ?? 'day'
+  const granularity: Granularity =
+    granularityRaw === 'week' || granularityRaw === 'month' ? granularityRaw : 'day'
+
+  const { from, to, label } = resolvePreset(preset)
+  const session = await getSession()
+  const summary = await getFinanceSummaryUseCase({
+    userId: session.userId!,
+    from,
+    to,
+    granularity,
+  })
+
+  const deltaPct = Number(summary.delta.receivedVsPreviousPeriod)
+  const deltaLabel = `${deltaPct >= 0 ? '+' : ''}${deltaPct.toFixed(1)}% vs período anterior`
+
+  return (
+    <div className="space-y-6 sm:space-y-8">
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="font-body text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Caixa & Previsão
+          </p>
+          <h1 className="font-display text-[30px] font-bold leading-tight text-foreground sm:text-[36px]">
+            Financeiro
+          </h1>
+          <p className="mt-1 font-body text-[14px] text-muted-foreground">
+            {label} • recebido vs previsto, quebras por local e área e pendências.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 self-start rounded-full bg-primary-soft px-3.5 py-2">
+          <CircleDollarSign className="h-4 w-4 text-primary" />
+          <span className="font-body text-[12px] font-semibold text-primary-soft-fg">
+            {money(summary.totalReceived)} no período
+          </span>
+        </div>
+      </div>
+
+      <FinancePeriodPicker preset={preset} granularity={granularity} />
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <FinanceSummaryCard
+          label="Recebido no período"
+          value={money(summary.totalReceived)}
+          delta={deltaLabel}
+          variant="received"
+        />
+        <FinanceSummaryCard
+          label="Previsto no período"
+          value={money(summary.totalForecast)}
+          delta={`${money(summary.forecastBySource.perSession)} sessões + ${money(
+            summary.forecastBySource.packageInstallments
+          )} pacotes`}
+          variant="forecast"
+        />
+        <FinanceSummaryCard
+          label="Período anterior"
+          value={money(summary.delta.previousReceived)}
+          variant="received"
+        />
+      </div>
+
+      <FinanceTimelineChart series={summary.series} />
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+        <FinanceBreakdownPanel
+          title="Por local de trabalho"
+          items={summary.byWorkplace.map((item) => ({
+            label: item.name,
+            received: item.received,
+            forecast: item.forecast,
+          }))}
+        />
+        <FinanceBreakdownPanel
+          title="Por área"
+          items={summary.byArea.map((item) => ({
+            label: AREA_LABELS[item.area] ?? item.area,
+            received: item.received,
+            forecast: item.forecast,
+          }))}
+        />
+      </div>
+
+      <PendingPaymentsTable items={summary.pendingPayments} />
+    </div>
+  )
+}

--- a/src/app/api/finance/summary/route.ts
+++ b/src/app/api/finance/summary/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+import type { TherapyArea } from '@/generated/prisma/client'
+import { getSession } from '@/lib/session'
+import { financeSummaryDTO } from '@/server/modules/finance/http/finance.dto'
+import { getFinanceSummaryUseCase } from '@/server/modules/finance/application/get-finance-summary'
+
+export async function GET(request: Request) {
+  const session = await getSession()
+  if (!session.userId) return NextResponse.json({ message: 'Não autorizado' }, { status: 401 })
+
+  const { searchParams } = new URL(request.url)
+  const parsed = financeSummaryDTO.safeParse({
+    from: searchParams.get('from') ?? undefined,
+    to: searchParams.get('to') ?? undefined,
+    granularity: searchParams.get('granularity') ?? undefined,
+    workplaceIds: searchParams.get('workplaceIds') ?? undefined,
+    areas: searchParams.get('areas') ?? undefined,
+  })
+
+  if (!parsed.success) {
+    return NextResponse.json({ errors: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const summary = await getFinanceSummaryUseCase({
+    userId: session.userId,
+    from: new Date(parsed.data.from),
+    to: new Date(parsed.data.to),
+    granularity: parsed.data.granularity,
+    workplaceIds: parsed.data.workplaceIds,
+    areas: parsed.data.areas as TherapyArea[] | undefined,
+  })
+
+  return NextResponse.json(summary)
+}

--- a/src/components/finance/FinanceBreakdownPanel.tsx
+++ b/src/components/finance/FinanceBreakdownPanel.tsx
@@ -1,0 +1,67 @@
+interface BreakdownItem {
+  label: string
+  received: string
+  forecast: string
+}
+
+interface FinanceBreakdownPanelProps {
+  title: string
+  items: BreakdownItem[]
+  emptyLabel?: string
+}
+
+function money(value: string) {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  }).format(Number(value))
+}
+
+export function FinanceBreakdownPanel({
+  title,
+  items,
+  emptyLabel = 'Sem dados no período.',
+}: FinanceBreakdownPanelProps) {
+  const max = Math.max(...items.map((item) => Number(item.received) + Number(item.forecast)), 1)
+
+  return (
+    <section className="rounded-[18px] border border-border bg-card p-4 shadow-sm sm:p-5">
+      <h3 className="font-display text-[15px] font-bold text-foreground">{title}</h3>
+      {items.length === 0 ? (
+        <p className="mt-3 font-body text-[12.5px] text-muted-foreground">{emptyLabel}</p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {items.map((item) => {
+            const total = Number(item.received) + Number(item.forecast)
+            const widthPct = (total / max) * 100
+            const receivedPct = total > 0 ? (Number(item.received) / total) * 100 : 0
+            return (
+              <div key={item.label} className="space-y-1.5">
+                <div className="flex items-center justify-between gap-3 font-body text-[12.5px]">
+                  <span className="font-semibold text-foreground">{item.label}</span>
+                  <span className="text-muted-foreground">
+                    {money(item.received)}{' '}
+                    <span className="opacity-60">+ {money(item.forecast)}</span>
+                  </span>
+                </div>
+                <div
+                  className="relative h-2 rounded-full bg-muted"
+                  style={{ width: `${Math.max(widthPct, 4)}%` }}
+                >
+                  <div
+                    className="absolute inset-y-0 left-0 rounded-full bg-[var(--color-primary)]"
+                    style={{ width: `${receivedPct}%` }}
+                  />
+                  <div
+                    className="absolute inset-y-0 right-0 rounded-full bg-[var(--color-accent)]"
+                    style={{ width: `${100 - receivedPct}%` }}
+                  />
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/finance/FinancePeriodPicker.tsx
+++ b/src/components/finance/FinancePeriodPicker.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { cn } from '@/lib/utils'
+
+interface PresetOption {
+  key: string
+  label: string
+}
+
+const PRESETS: PresetOption[] = [
+  { key: 'today', label: 'Hoje' },
+  { key: '7d', label: '7 dias' },
+  { key: '30d', label: '30 dias' },
+  { key: 'month', label: 'Este mês' },
+  { key: 'last-month', label: 'Mês anterior' },
+]
+
+const GRANULARITY_OPTIONS = [
+  { value: 'day', label: 'Dia' },
+  { value: 'week', label: 'Semana' },
+  { value: 'month', label: 'Mês' },
+] as const
+
+interface FinancePeriodPickerProps {
+  preset: string
+  granularity: 'day' | 'week' | 'month'
+}
+
+export function FinancePeriodPicker({ preset, granularity }: FinancePeriodPickerProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  function setParam(key: string, value: string) {
+    const next = new URLSearchParams(searchParams.toString())
+    next.set(key, value)
+    router.push(`/financeiro?${next.toString()}`)
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-[18px] border border-border bg-card p-3 shadow-sm sm:p-4">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="font-body text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          Período
+        </span>
+        {PRESETS.map((option) => (
+          <button
+            key={option.key}
+            type="button"
+            onClick={() => setParam('preset', option.key)}
+            className={cn(
+              'rounded-full px-3 py-1.5 font-body text-[12px] font-semibold transition-colors',
+              preset === option.key
+                ? 'bg-primary text-primary-foreground shadow-glow'
+                : 'bg-muted text-muted-foreground hover:bg-primary-soft hover:text-primary-soft-fg'
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="ml-auto flex items-center gap-1.5">
+        <span className="font-body text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          Agrupar
+        </span>
+        {GRANULARITY_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => setParam('granularity', option.value)}
+            className={cn(
+              'rounded-full px-3 py-1.5 font-body text-[12px] font-semibold transition-colors',
+              granularity === option.value
+                ? 'bg-primary text-primary-foreground shadow-glow'
+                : 'bg-muted text-muted-foreground hover:bg-primary-soft hover:text-primary-soft-fg'
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/finance/FinanceSummaryCard.tsx
+++ b/src/components/finance/FinanceSummaryCard.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/lib/utils'
+
+interface FinanceSummaryCardProps {
+  label: string
+  value: string
+  delta?: string
+  variant?: 'received' | 'forecast'
+}
+
+const VARIANT_CLASSES = {
+  received: 'bg-success-soft text-success',
+  forecast: 'bg-warning-soft text-warning',
+} as const
+
+export function FinanceSummaryCard({
+  label,
+  value,
+  delta,
+  variant = 'received',
+}: FinanceSummaryCardProps) {
+  return (
+    <div className="rounded-[18px] border border-border bg-card p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <p className="font-body text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          {label}
+        </p>
+        {delta ? (
+          <span
+            className={cn(
+              'rounded-full px-2 py-0.5 font-body text-[10.5px] font-semibold',
+              VARIANT_CLASSES[variant]
+            )}
+          >
+            {delta}
+          </span>
+        ) : null}
+      </div>
+      <p className="mt-3 font-display text-[26px] font-bold text-foreground sm:text-[28px]">
+        {value}
+      </p>
+    </div>
+  )
+}

--- a/src/components/finance/FinanceTimelineChart.tsx
+++ b/src/components/finance/FinanceTimelineChart.tsx
@@ -1,0 +1,148 @@
+interface SeriesPoint {
+  bucket: string
+  received: string
+  forecast: string
+}
+
+interface FinanceTimelineChartProps {
+  series: SeriesPoint[]
+}
+
+function moneyShort(value: number) {
+  if (value >= 1000) return `R$ ${(value / 1000).toFixed(1)}k`
+  return `R$ ${value.toFixed(0)}`
+}
+
+function dayLabel(bucket: string) {
+  const [, m, d] = bucket.split('-')
+  return `${d}/${m}`
+}
+
+export function FinanceTimelineChart({ series }: FinanceTimelineChartProps) {
+  if (series.length === 0) {
+    return (
+      <div className="rounded-[18px] border border-border bg-card p-6 text-center">
+        <p className="font-body text-[13px] text-muted-foreground">
+          Sem dados no período selecionado.
+        </p>
+      </div>
+    )
+  }
+
+  const width = 720
+  const height = 240
+  const padX = 40
+  const padY = 24
+
+  const max = Math.max(...series.map((p) => Math.max(Number(p.received), Number(p.forecast))), 1)
+  const stepX = series.length > 1 ? (width - padX * 2) / (series.length - 1) : 0
+
+  const toY = (value: number) => height - padY - ((height - padY * 2) * value) / max
+
+  const buildPath = (key: 'received' | 'forecast') =>
+    series
+      .map((point, index) => {
+        const x = padX + index * stepX
+        const y = toY(Number(point[key]))
+        return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`
+      })
+      .join(' ')
+
+  const receivedPath = buildPath('received')
+  const forecastPath = buildPath('forecast')
+
+  return (
+    <div className="rounded-[18px] border border-border bg-card p-4 shadow-sm sm:p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="font-display text-[15px] font-bold text-foreground">Recebido vs Previsto</h3>
+        <div className="flex items-center gap-3 font-body text-[11px] text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-[var(--color-primary)]" />
+            Recebido
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-[var(--color-accent)]" />
+            Previsto
+          </span>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${width} ${height}`}
+          className="w-full"
+          preserveAspectRatio="none"
+          style={{ minWidth: 480 }}
+        >
+          {[0.25, 0.5, 0.75, 1].map((ratio) => (
+            <line
+              key={ratio}
+              x1={padX}
+              x2={width - padX}
+              y1={toY(max * ratio)}
+              y2={toY(max * ratio)}
+              stroke="var(--color-border)"
+              strokeWidth={1}
+              strokeDasharray="3 4"
+            />
+          ))}
+
+          <path
+            d={forecastPath}
+            fill="none"
+            stroke="var(--color-accent)"
+            strokeWidth={2.5}
+            strokeLinejoin="round"
+          />
+          <path
+            d={receivedPath}
+            fill="none"
+            stroke="var(--color-primary)"
+            strokeWidth={2.5}
+            strokeLinejoin="round"
+          />
+
+          {series.map((point, index) => {
+            const x = padX + index * stepX
+            return (
+              <g key={point.bucket}>
+                <circle cx={x} cy={toY(Number(point.received))} r={3} fill="var(--color-primary)" />
+                <circle cx={x} cy={toY(Number(point.forecast))} r={3} fill="var(--color-accent)" />
+                {index % Math.max(1, Math.floor(series.length / 8)) === 0 ? (
+                  <text
+                    x={x}
+                    y={height - 6}
+                    textAnchor="middle"
+                    fontSize="10"
+                    fill="var(--color-muted-foreground)"
+                  >
+                    {dayLabel(point.bucket)}
+                  </text>
+                ) : null}
+              </g>
+            )
+          })}
+
+          <text
+            x={padX - 6}
+            y={toY(max)}
+            textAnchor="end"
+            fontSize="10"
+            fill="var(--color-muted-foreground)"
+          >
+            {moneyShort(max)}
+          </text>
+          <text
+            x={padX - 6}
+            y={toY(0) + 3}
+            textAnchor="end"
+            fontSize="10"
+            fill="var(--color-muted-foreground)"
+          >
+            R$ 0
+          </text>
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/src/components/finance/PendingPaymentsTable.tsx
+++ b/src/components/finance/PendingPaymentsTable.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Wallet } from 'lucide-react'
+import { RegisterPaymentModal } from '@/components/payments/RegisterPaymentModal'
+
+interface PendingPayment {
+  id: string
+  patientName: string
+  planLabel: string | null
+  amount: string
+  dueAt: string | null
+  method: string
+  treatmentPlanId?: string | null
+  patientId?: string | null
+}
+
+const METHOD_LABELS: Record<string, string> = {
+  PIX: 'PIX',
+  CASH: 'Dinheiro',
+  CREDIT_CARD: 'Crédito',
+  DEBIT_CARD: 'Débito',
+  BANK_TRANSFER: 'Transferência',
+  INSURANCE: 'Convênio',
+  OTHER: 'Outro',
+}
+
+function money(value: string) {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  }).format(Number(value))
+}
+
+function dateLabel(value: string | null) {
+  if (!value) return '—'
+  return new Date(value).toLocaleDateString('pt-BR')
+}
+
+export function PendingPaymentsTable({ items }: { items: PendingPayment[] }) {
+  const router = useRouter()
+  const [paying, setPaying] = useState<PendingPayment | null>(null)
+
+  return (
+    <section className="rounded-[18px] border border-border bg-card p-4 shadow-sm sm:p-5">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="font-display text-[15px] font-bold text-foreground">Pagamentos pendentes</h3>
+        <span className="rounded-full bg-warning-soft px-2.5 py-1 font-body text-[11px] font-semibold text-warning">
+          {items.length} em aberto
+        </span>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="font-body text-[12.5px] text-muted-foreground">
+          Nenhum pagamento pendente — tudo em dia.
+        </p>
+      ) : (
+        <div className="overflow-hidden rounded-[14px] border border-border">
+          <table className="w-full text-left font-body text-[12.5px]">
+            <thead className="bg-muted/50 text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 font-semibold">Paciente</th>
+                <th className="px-3 py-2 font-semibold">Origem</th>
+                <th className="px-3 py-2 font-semibold">Método</th>
+                <th className="px-3 py-2 font-semibold">Vence em</th>
+                <th className="px-3 py-2 text-right font-semibold">Valor</th>
+                <th className="px-3 py-2 text-right font-semibold">Ações</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => (
+                <tr key={item.id} className="border-t border-border">
+                  <td className="px-3 py-2 font-semibold text-foreground">
+                    {item.patientId ? (
+                      <Link
+                        href={`/pacientes/${item.patientId}`}
+                        className="hover:text-primary hover:underline"
+                      >
+                        {item.patientName}
+                      </Link>
+                    ) : (
+                      item.patientName
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">{item.planLabel ?? '—'}</td>
+                  <td className="px-3 py-2">{METHOD_LABELS[item.method] ?? item.method}</td>
+                  <td className="px-3 py-2">{dateLabel(item.dueAt)}</td>
+                  <td className="px-3 py-2 text-right font-semibold">{money(item.amount)}</td>
+                  <td className="px-3 py-2 text-right">
+                    {item.treatmentPlanId ? (
+                      <button
+                        type="button"
+                        onClick={() => setPaying(item)}
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1 font-body text-[11.5px] font-semibold text-foreground transition-colors hover:border-primary/40 hover:bg-primary-soft"
+                      >
+                        <Wallet className="h-3 w-3" />
+                        Marcar pago
+                      </button>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {paying && paying.treatmentPlanId ? (
+        <RegisterPaymentModal
+          open
+          target={{ kind: 'plan', planId: paying.treatmentPlanId }}
+          defaultAmount={Number(paying.amount)}
+          onClose={() => setPaying(null)}
+          onSuccess={() => router.refresh()}
+        />
+      ) : null}
+    </section>
+  )
+}

--- a/src/components/layout/navigation.ts
+++ b/src/components/layout/navigation.ts
@@ -1,6 +1,7 @@
 import type { LucideIcon } from 'lucide-react'
 import {
   Calendar,
+  CircleDollarSign,
   ClipboardList,
   FileText,
   HelpCircle,
@@ -22,6 +23,7 @@ export const primaryNavigation: NavigationItem[] = [
   { label: 'Atendimentos', href: '/atendimentos', icon: ClipboardList },
   { label: 'Agenda', href: '/agenda', icon: Calendar },
   { label: 'Documentos', href: '/documentos', icon: FileText },
+  { label: 'Financeiro', href: '/financeiro', icon: CircleDollarSign },
 ]
 
 export const secondaryNavigation: NavigationItem[] = [
@@ -36,6 +38,7 @@ export const pageTitles: Record<string, string> = {
   '/atendimentos': 'Atendimentos',
   '/agenda': 'Agenda',
   '/documentos': 'Documentos',
+  '/financeiro': 'Financeiro',
   '/configuracoes': 'Configurações',
 }
 

--- a/src/lib/serialize-session.ts
+++ b/src/lib/serialize-session.ts
@@ -2,7 +2,8 @@ export function serializeSession<T extends { expectedFee?: unknown }>(session: T
   return {
     ...session,
     expectedFee:
-      session.expectedFee != null && typeof (session.expectedFee as { toString?: () => string }).toString === 'function'
+      session.expectedFee != null &&
+      typeof (session.expectedFee as { toString?: () => string }).toString === 'function'
         ? (session.expectedFee as { toString: () => string }).toString()
         : null,
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,6 +19,7 @@ const APP_PATHS = [
   '/atendimentos',
   '/agenda',
   '/documentos',
+  '/financeiro',
   '/configuracoes',
 ]
 
@@ -51,6 +52,7 @@ export const config = {
     '/atendimentos/:path*',
     '/agenda/:path*',
     '/documentos/:path*',
+    '/financeiro/:path*',
     '/configuracoes/:path*',
     '/login',
     '/register',

--- a/src/server/modules/finance/application/get-finance-summary.test.ts
+++ b/src/server/modules/finance/application/get-finance-summary.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/prisma', () => {
+  return {
+    prisma: {
+      payment: {
+        findMany: vi.fn(),
+        aggregate: vi.fn(),
+      },
+      session: {
+        findMany: vi.fn(),
+      },
+      workplace: {
+        findMany: vi.fn(),
+      },
+    },
+  }
+})
+
+import { prisma } from '@/lib/prisma'
+import { getFinanceSummaryUseCase } from './get-finance-summary'
+
+const mockPaymentFindMany = vi.mocked(prisma.payment.findMany)
+const mockPaymentAggregate = vi.mocked(prisma.payment.aggregate)
+const mockSessionFindMany = vi.mocked(prisma.session.findMany)
+const mockWorkplaceFindMany = vi.mocked(prisma.workplace.findMany)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockWorkplaceFindMany.mockResolvedValue([
+    { id: 'wp-1', name: 'Clínica Movimento' },
+    { id: 'wp-2', name: 'Atendimento Particular' },
+  ] as never)
+})
+
+describe('getFinanceSummaryUseCase', () => {
+  it('agrega recebido, previsto e quebras corretamente', async () => {
+    // Pagamentos no período (PAID)
+    mockPaymentFindMany.mockImplementation(((args: { where?: { status?: unknown } }) => {
+      const status = args?.where?.status
+      if (typeof status === 'object' && status && 'in' in status) {
+        // recebidos
+        return Promise.resolve([
+          {
+            amount: 200,
+            paidAt: new Date('2026-04-10T12:00:00Z'),
+            treatmentPlan: { workplaceId: 'wp-1', area: 'ORTOPEDICA' },
+            session: null,
+          },
+          {
+            amount: 300,
+            paidAt: new Date('2026-04-15T12:00:00Z'),
+            treatmentPlan: null,
+            session: { workplaceId: 'wp-2', treatmentPlan: { area: 'ESTETICA' } },
+          },
+        ]) as never
+      }
+      if (status === 'PENDING') {
+        // tabela de pendências OU parcelas
+        // o use case chama findMany duas vezes para PENDING:
+        //  - a primeira sem `take` nem `orderBy` (parcelas para forecast)
+        //  - a segunda com `take: 50` e `orderBy` (lista de pendências)
+        if ((args as { take?: number }).take === 50) {
+          return Promise.resolve([
+            {
+              id: 'p-pend-1',
+              amount: 150,
+              dueAt: new Date('2026-05-01T00:00:00Z'),
+              method: 'PIX',
+              treatmentPlan: {
+                id: 'plan-1',
+                area: 'ORTOPEDICA',
+                pricingModel: 'PACKAGE',
+                patient: { id: 'pat-1', name: 'Maria Silva' },
+              },
+              session: null,
+            },
+          ]) as never
+        }
+        return Promise.resolve([
+          {
+            amount: 150,
+            dueAt: new Date('2026-04-25T00:00:00Z'),
+            method: 'PIX',
+            notes: null,
+            treatmentPlan: {
+              workplaceId: 'wp-1',
+              area: 'ORTOPEDICA',
+              patient: { name: 'Maria Silva' },
+            },
+          },
+        ]) as never
+      }
+      return Promise.resolve([]) as never
+    }) as never)
+
+    mockSessionFindMany.mockResolvedValue([
+      {
+        id: 's-future-1',
+        date: new Date('2026-04-20T12:00:00Z'),
+        expectedFee: 180,
+        workplaceId: 'wp-1',
+        treatmentPlan: { area: 'ORTOPEDICA' },
+      },
+    ] as never)
+
+    mockPaymentAggregate.mockResolvedValue({ _sum: { amount: 100 } } as never)
+
+    const result = await getFinanceSummaryUseCase({
+      userId: 'u1',
+      from: new Date('2026-04-01T00:00:00Z'),
+      to: new Date('2026-04-30T23:59:59Z'),
+      granularity: 'day',
+    })
+
+    expect(result.totalReceived).toBe('500.00')
+    expect(result.totalForecast).toBe('330.00')
+    expect(result.forecastBySource.perSession).toBe('180.00')
+    expect(result.forecastBySource.packageInstallments).toBe('150.00')
+    expect(result.delta.previousReceived).toBe('100.00')
+    expect(result.delta.receivedVsPreviousPeriod).toBe('400.0')
+    expect(result.byWorkplace.length).toBe(2)
+    expect(result.byArea.length).toBe(2)
+    expect(result.pendingPayments[0]).toMatchObject({
+      patientName: 'Maria Silva',
+      treatmentPlanId: 'plan-1',
+      amount: '150.00',
+    })
+    expect(result.series.length).toBeGreaterThanOrEqual(29)
+  })
+
+  it('retorna zeros quando não há pagamentos nem sessões', async () => {
+    mockPaymentFindMany.mockResolvedValue([] as never)
+    mockSessionFindMany.mockResolvedValue([] as never)
+    mockPaymentAggregate.mockResolvedValue({ _sum: { amount: null } } as never)
+
+    const result = await getFinanceSummaryUseCase({
+      userId: 'u1',
+      from: new Date('2026-04-01T00:00:00Z'),
+      to: new Date('2026-04-07T23:59:59Z'),
+      granularity: 'day',
+    })
+
+    expect(result.totalReceived).toBe('0.00')
+    expect(result.totalForecast).toBe('0.00')
+    expect(result.delta.receivedVsPreviousPeriod).toBe('0.0')
+    expect(result.pendingPayments).toEqual([])
+  })
+})

--- a/src/server/modules/finance/application/get-finance-summary.ts
+++ b/src/server/modules/finance/application/get-finance-summary.ts
@@ -1,0 +1,380 @@
+import { prisma } from '@/lib/prisma'
+import type { Prisma, TherapyArea } from '@/generated/prisma/client'
+import type {
+  FinanceBreakdownByArea,
+  FinanceBreakdownByWorkplace,
+  FinancePendingPayment,
+  FinanceSeriesPoint,
+  FinanceSummary,
+  Granularity,
+} from '../domain/finance'
+
+interface UseCaseInput {
+  userId: string
+  from: Date
+  to: Date
+  granularity: Granularity
+  workplaceIds?: string[]
+  areas?: TherapyArea[]
+}
+
+function toMoneyString(value: number) {
+  return value.toFixed(2)
+}
+
+function clampDate(value: Date) {
+  const next = new Date(value.getTime())
+  next.setHours(0, 0, 0, 0)
+  return next
+}
+
+function endOfDay(value: Date) {
+  const next = new Date(value.getTime())
+  next.setHours(23, 59, 59, 999)
+  return next
+}
+
+function startOfWeek(value: Date) {
+  const next = clampDate(value)
+  const day = next.getDay() // 0 = Sun
+  const diff = day === 0 ? 6 : day - 1
+  next.setDate(next.getDate() - diff)
+  return next
+}
+
+function startOfMonth(value: Date) {
+  const next = clampDate(value)
+  next.setDate(1)
+  return next
+}
+
+function bucketKey(date: Date, granularity: Granularity) {
+  let bucket: Date
+  if (granularity === 'week') bucket = startOfWeek(date)
+  else if (granularity === 'month') bucket = startOfMonth(date)
+  else bucket = clampDate(date)
+  const y = bucket.getFullYear()
+  const m = String(bucket.getMonth() + 1).padStart(2, '0')
+  const d = String(bucket.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+function enumerateBuckets(from: Date, to: Date, granularity: Granularity) {
+  const keys = new Set<string>()
+  const current = clampDate(from)
+  const limit = clampDate(to)
+  while (current <= limit) {
+    keys.add(bucketKey(current, granularity))
+    if (granularity === 'week') current.setDate(current.getDate() + 7)
+    else if (granularity === 'month') current.setMonth(current.getMonth() + 1)
+    else current.setDate(current.getDate() + 1)
+  }
+  return Array.from(keys)
+}
+
+export async function getFinanceSummaryUseCase(input: UseCaseInput): Promise<FinanceSummary> {
+  const { userId, from, to, granularity, workplaceIds, areas } = input
+
+  const workplaceFilter = workplaceIds && workplaceIds.length > 0 ? workplaceIds : undefined
+  const areaFilter = areas && areas.length > 0 ? areas : undefined
+
+  // 1. Pagamentos recebidos no período (status PAID/PARTIAL)
+  const paymentsInRange = await prisma.payment.findMany({
+    where: {
+      userId,
+      status: { in: ['PAID', 'PARTIAL'] },
+      paidAt: { gte: from, lte: to },
+      ...(workplaceFilter || areaFilter
+        ? {
+            OR: [
+              {
+                treatmentPlan: {
+                  ...(workplaceFilter ? { workplaceId: { in: workplaceFilter } } : {}),
+                  ...(areaFilter ? { area: { in: areaFilter } } : {}),
+                },
+              },
+              {
+                session: {
+                  ...(workplaceFilter ? { workplaceId: { in: workplaceFilter } } : {}),
+                  ...(areaFilter ? { treatmentPlan: { area: { in: areaFilter } } } : {}),
+                },
+              },
+            ],
+          }
+        : {}),
+    },
+    include: {
+      treatmentPlan: { select: { workplaceId: true, area: true } },
+      session: {
+        select: {
+          workplaceId: true,
+          treatmentPlan: { select: { area: true } },
+        },
+      },
+    },
+  })
+
+  // 2. Sessões agendadas com previsão de cobrança no período
+  const forecastSessions = await prisma.session.findMany({
+    where: {
+      userId,
+      isActive: true,
+      status: 'AGENDADO',
+      date: { gte: from, lte: to },
+      expectedFee: { gt: 0 },
+      paymentStatus: { in: ['PENDING', 'PARTIAL'] },
+      ...(workplaceFilter ? { workplaceId: { in: workplaceFilter } } : {}),
+      ...(areaFilter ? { treatmentPlan: { area: { in: areaFilter } } } : {}),
+    },
+    select: {
+      id: true,
+      date: true,
+      expectedFee: true,
+      workplaceId: true,
+      treatmentPlan: { select: { area: true } },
+    },
+  })
+
+  // 3. Parcelas pendentes de pacote no período (Payment.status=PENDING com dueAt)
+  const forecastInstallments = await prisma.payment.findMany({
+    where: {
+      userId,
+      status: 'PENDING',
+      dueAt: { gte: from, lte: to },
+      ...(workplaceFilter || areaFilter
+        ? {
+            treatmentPlan: {
+              ...(workplaceFilter ? { workplaceId: { in: workplaceFilter } } : {}),
+              ...(areaFilter ? { area: { in: areaFilter } } : {}),
+            },
+          }
+        : {}),
+    },
+    select: {
+      id: true,
+      amount: true,
+      dueAt: true,
+      method: true,
+      notes: true,
+      treatmentPlan: {
+        select: {
+          workplaceId: true,
+          area: true,
+          patient: { select: { name: true } },
+        },
+      },
+    },
+  })
+
+  // 4. Período anterior — recebido (mesmo tamanho)
+  const periodMs = endOfDay(to).getTime() - clampDate(from).getTime()
+  const previousFrom = new Date(clampDate(from).getTime() - periodMs - 1)
+  const previousTo = new Date(clampDate(from).getTime() - 1)
+  const previousAgg = await prisma.payment.aggregate({
+    where: {
+      userId,
+      status: { in: ['PAID', 'PARTIAL'] },
+      paidAt: { gte: previousFrom, lte: previousTo },
+    },
+    _sum: { amount: true },
+  })
+  const previousReceived = Number(previousAgg._sum.amount ?? 0)
+
+  // 5. Totais e séries
+  const totalReceived = paymentsInRange.reduce((sum, p) => sum + Number(p.amount), 0)
+  const forecastPerSession = forecastSessions.reduce(
+    (sum, s) => sum + (s.expectedFee ? Number(s.expectedFee) : 0),
+    0
+  )
+  const forecastPackages = forecastInstallments.reduce((sum, p) => sum + Number(p.amount), 0)
+  const totalForecast = forecastPerSession + forecastPackages
+
+  const buckets = enumerateBuckets(from, to, granularity)
+  const seriesMap: Record<string, { received: number; forecast: number }> = {}
+  for (const key of buckets) seriesMap[key] = { received: 0, forecast: 0 }
+
+  for (const payment of paymentsInRange) {
+    const key = bucketKey(payment.paidAt, granularity)
+    if (!seriesMap[key]) seriesMap[key] = { received: 0, forecast: 0 }
+    seriesMap[key].received += Number(payment.amount)
+  }
+  for (const session of forecastSessions) {
+    const key = bucketKey(session.date, granularity)
+    if (!seriesMap[key]) seriesMap[key] = { received: 0, forecast: 0 }
+    seriesMap[key].forecast += session.expectedFee ? Number(session.expectedFee) : 0
+  }
+  for (const installment of forecastInstallments) {
+    if (!installment.dueAt) continue
+    const key = bucketKey(installment.dueAt, granularity)
+    if (!seriesMap[key]) seriesMap[key] = { received: 0, forecast: 0 }
+    seriesMap[key].forecast += Number(installment.amount)
+  }
+
+  const series: FinanceSeriesPoint[] = Object.entries(seriesMap)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([bucket, totals]) => ({
+      bucket,
+      received: toMoneyString(totals.received),
+      forecast: toMoneyString(totals.forecast),
+    }))
+
+  // 6. Breakdown por workplace
+  const workplaceLookup = await prisma.workplace.findMany({
+    where: { userId },
+    select: { id: true, name: true },
+  })
+  const workplaceNames = new Map(workplaceLookup.map((w) => [w.id, w.name]))
+
+  const workplaceTotals: Record<string, { received: number; forecast: number }> = {}
+  function addWorkplace(
+    id: string | null | undefined,
+    kind: 'received' | 'forecast',
+    value: number
+  ) {
+    if (!id) return
+    if (!workplaceTotals[id]) workplaceTotals[id] = { received: 0, forecast: 0 }
+    workplaceTotals[id][kind] += value
+  }
+
+  for (const payment of paymentsInRange) {
+    const id = payment.treatmentPlan?.workplaceId ?? payment.session?.workplaceId ?? null
+    addWorkplace(id, 'received', Number(payment.amount))
+  }
+  for (const session of forecastSessions) {
+    addWorkplace(
+      session.workplaceId,
+      'forecast',
+      session.expectedFee ? Number(session.expectedFee) : 0
+    )
+  }
+  for (const installment of forecastInstallments) {
+    addWorkplace(installment.treatmentPlan?.workplaceId, 'forecast', Number(installment.amount))
+  }
+
+  const byWorkplace: FinanceBreakdownByWorkplace[] = Object.entries(workplaceTotals)
+    .map(([id, totals]) => ({
+      workplaceId: id,
+      name: workplaceNames.get(id) ?? 'Local removido',
+      received: toMoneyString(totals.received),
+      forecast: toMoneyString(totals.forecast),
+    }))
+    .sort(
+      (a, b) => Number(b.received) + Number(b.forecast) - (Number(a.received) + Number(a.forecast))
+    )
+
+  // 7. Breakdown por área
+  const areaTotals: Record<string, { received: number; forecast: number }> = {}
+  function addArea(area: string | null | undefined, kind: 'received' | 'forecast', value: number) {
+    if (!area) return
+    if (!areaTotals[area]) areaTotals[area] = { received: 0, forecast: 0 }
+    areaTotals[area][kind] += value
+  }
+
+  for (const payment of paymentsInRange) {
+    const area = payment.treatmentPlan?.area ?? payment.session?.treatmentPlan?.area ?? null
+    addArea(area, 'received', Number(payment.amount))
+  }
+  for (const session of forecastSessions) {
+    addArea(
+      session.treatmentPlan?.area,
+      'forecast',
+      session.expectedFee ? Number(session.expectedFee) : 0
+    )
+  }
+  for (const installment of forecastInstallments) {
+    addArea(installment.treatmentPlan?.area, 'forecast', Number(installment.amount))
+  }
+
+  const byArea: FinanceBreakdownByArea[] = Object.entries(areaTotals)
+    .map(([area, totals]) => ({
+      area,
+      received: toMoneyString(totals.received),
+      forecast: toMoneyString(totals.forecast),
+    }))
+    .sort(
+      (a, b) => Number(b.received) + Number(b.forecast) - (Number(a.received) + Number(a.forecast))
+    )
+
+  // 8. Pendências (Payment.status=PENDING, ordem por dueAt asc, top 50)
+  const pendingPaymentsRaw = await prisma.payment.findMany({
+    where: {
+      userId,
+      status: 'PENDING',
+      ...(workplaceFilter || areaFilter
+        ? {
+            treatmentPlan: {
+              ...(workplaceFilter ? { workplaceId: { in: workplaceFilter } } : {}),
+              ...(areaFilter ? { area: { in: areaFilter } } : {}),
+            },
+          }
+        : {}),
+    },
+    take: 50,
+    orderBy: [{ dueAt: 'asc' }, { createdAt: 'asc' }],
+    include: {
+      treatmentPlan: {
+        select: {
+          id: true,
+          area: true,
+          pricingModel: true,
+          patient: { select: { id: true, name: true } },
+        },
+      },
+      session: {
+        select: {
+          patient: { select: { id: true, name: true } },
+          treatmentPlan: { select: { area: true } },
+        },
+      },
+    },
+  } satisfies Prisma.PaymentFindManyArgs)
+
+  const pendingPayments: FinancePendingPayment[] = pendingPaymentsRaw.map((p) => {
+    const patientName = p.treatmentPlan?.patient.name ?? p.session?.patient.name ?? 'Paciente'
+    const area = p.treatmentPlan?.area ?? p.session?.treatmentPlan?.area ?? null
+    const planLabel = p.treatmentPlan
+      ? p.treatmentPlan.pricingModel === 'PACKAGE'
+        ? `Pacote (${area ?? 'plano'})`
+        : `Plano (${area ?? 'avulso'})`
+      : 'Sessão avulsa'
+    return {
+      id: p.id,
+      patientId: p.treatmentPlan?.patient.id ?? p.session?.patient.id ?? null,
+      patientName,
+      treatmentPlanId: p.treatmentPlan?.id ?? null,
+      planLabel,
+      amount: toMoneyString(Number(p.amount)),
+      dueAt: p.dueAt ? p.dueAt.toISOString() : null,
+      method: p.method,
+    }
+  })
+
+  const deltaPct =
+    previousReceived > 0
+      ? ((totalReceived - previousReceived) / previousReceived) * 100
+      : totalReceived > 0
+        ? 100
+        : 0
+
+  return {
+    range: {
+      from: clampDate(from).toISOString().slice(0, 10),
+      to: clampDate(to).toISOString().slice(0, 10),
+      granularity,
+    },
+    totalReceived: toMoneyString(totalReceived),
+    totalForecast: toMoneyString(totalForecast),
+    forecastBySource: {
+      perSession: toMoneyString(forecastPerSession),
+      packageInstallments: toMoneyString(forecastPackages),
+    },
+    delta: {
+      receivedVsPreviousPeriod: deltaPct.toFixed(1),
+      previousReceived: toMoneyString(previousReceived),
+    },
+    series,
+    byWorkplace,
+    byArea,
+    pendingPayments,
+  }
+}

--- a/src/server/modules/finance/domain/finance.ts
+++ b/src/server/modules/finance/domain/finance.ts
@@ -1,0 +1,43 @@
+export type Granularity = 'day' | 'week' | 'month'
+
+export interface FinanceSeriesPoint {
+  bucket: string
+  received: string
+  forecast: string
+}
+
+export interface FinanceBreakdownByWorkplace {
+  workplaceId: string
+  name: string
+  received: string
+  forecast: string
+}
+
+export interface FinanceBreakdownByArea {
+  area: string
+  received: string
+  forecast: string
+}
+
+export interface FinancePendingPayment {
+  id: string
+  patientId: string | null
+  patientName: string
+  treatmentPlanId: string | null
+  planLabel: string | null
+  amount: string
+  dueAt: string | null
+  method: string
+}
+
+export interface FinanceSummary {
+  range: { from: string; to: string; granularity: Granularity }
+  totalReceived: string
+  totalForecast: string
+  forecastBySource: { perSession: string; packageInstallments: string }
+  delta: { receivedVsPreviousPeriod: string; previousReceived: string }
+  series: FinanceSeriesPoint[]
+  byWorkplace: FinanceBreakdownByWorkplace[]
+  byArea: FinanceBreakdownByArea[]
+  pendingPayments: FinancePendingPayment[]
+}

--- a/src/server/modules/finance/http/finance.dto.ts
+++ b/src/server/modules/finance/http/finance.dto.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+const requiredDateString = z
+  .string()
+  .trim()
+  .refine((value) => !Number.isNaN(Date.parse(value)), 'Data inválida')
+
+const granularityEnum = z.enum(['day', 'week', 'month'])
+
+const therapyAreaEnum = z.enum([
+  'ORTOPEDICA',
+  'NEUROLOGICA',
+  'CARDIORESPIRATORIA',
+  'ESTETICA',
+  'ESPORTIVA',
+  'PELVICA',
+  'PEDIATRICA',
+  'GERIATRICA',
+  'PREVENTIVA',
+  'OUTRA',
+])
+
+function splitCSV(value: string | undefined) {
+  if (!value) return undefined
+  const items = value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+  return items.length > 0 ? items : undefined
+}
+
+export const financeSummaryDTO = z.object({
+  from: requiredDateString,
+  to: requiredDateString,
+  granularity: granularityEnum.default('day'),
+  workplaceIds: z.string().optional().transform(splitCSV).pipe(z.array(z.string()).optional()),
+  areas: z.string().optional().transform(splitCSV).pipe(z.array(therapyAreaEnum).optional()),
+})
+
+export type FinanceSummaryDTO = z.infer<typeof financeSummaryDTO>


### PR DESCRIPTION
## Summary

- Novo módulo `finance` (somente leitura) com `getFinanceSummaryUseCase` agregando recebido, previsto por sessões/pacotes, série temporal, breakdowns por local e área e pendências
- Endpoint `GET /api/finance/summary?from&to&granularity&workplaceIds&areas` com `Decimal` serializado como string
- Página `/financeiro` com period picker (presets + granularidade), 3 cards de KPI, gráfico SVG nativo (sem dependência externa), breakdowns visuais e tabela de pendências com ação "Marcar pago" reaproveitando o `RegisterPaymentModal` da Phase 16
- Mini-cards "Caixa do mês" e "A receber este mês" no `/dashboard` linkando para `/financeiro?preset=month`
- Sidebar com link "Financeiro" (ícone `CircleDollarSign`); proxy autenticado cobre `/financeiro/**`
- **PhysioFlow v2** (multi-modalidade + financeiro) entregue ao final desta fase

Closes #7

## Endpoints novos

- `GET /api/finance/summary?from=YYYY-MM-DD&to=YYYY-MM-DD&granularity=day|week|month&workplaceIds=&areas=` — retorna `totalReceived`, `totalForecast`, `forecastBySource`, `delta`, `series[]`, `byWorkplace[]`, `byArea[]`, `pendingPayments[]`

## Test plan

- [x] `npm run lint` sem erros
- [x] `npm run build` sem erros
- [x] `npm test` — 41 testes passando (incluindo `getFinanceSummaryUseCase` com cenário com dados e cenário vazio)
- [ ] Validar manualmente no navegador: `/financeiro` carrega cards, gráfico, breakdowns e pendências
- [ ] Trocar preset (hoje, 7d, 30d, mês, mês anterior) e granularidade (dia, semana, mês) — URL e dados atualizam
- [ ] Clicar "Marcar pago" em pendência de pacote abre o modal e atualiza após salvar
- [ ] Mini-cards no `/dashboard` mostram caixa e a receber do mês e linkam para `/financeiro`
- [ ] Performance OK na base demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)